### PR TITLE
Add option to Load font files

### DIFF
--- a/manimpango/cmanimpango.pxd
+++ b/manimpango/cmanimpango.pxd
@@ -128,3 +128,13 @@ cdef extern from "pango/pangocairo.h":
         int* height
     )
     const char* pango_version_string()
+IF UNAME_SYSNAME == "Linux":
+    cdef extern from "fontconfig/fontconfig.h":
+        ctypedef int FcBool
+        ctypedef struct FcConfig:
+            pass
+        FcBool FcConfigAppFontAddFile(
+            FcConfig* config,
+            const unsigned char* file_name
+        )
+        FcConfig* FcConfigGetCurrent()

--- a/manimpango/cmanimpango.pyx
+++ b/manimpango/cmanimpango.pyx
@@ -378,7 +378,7 @@ IF UNAME_SYSNAME == "Linux":
             Font is missing.
         """
         a=Path(font_path)
-        assert a.exists(), f"font doesn't exists at {a.absolute()}"
+        assert a.exists(), f"font doesn't exist at {a.absolute()}"
         font_path = str(a.absolute())
         font_path_bytes=font_path.encode('ascii')
         cdef const unsigned char* fontPath = font_path_bytes

--- a/manimpango/cmanimpango.pyx
+++ b/manimpango/cmanimpango.pyx
@@ -354,3 +354,36 @@ cpdef str pango_version():
 
 cpdef str cairo_version():
     return cairo_version_string().decode('utf-8')
+
+IF UNAME_SYSNAME == "Linux":
+    cpdef bint register_font(str font_path):
+        """This function registers the font file using ``fontconfig`` so that
+        it is available for use by Pango.
+        Parameters
+        ==========
+        font_path : :class:`str`
+            Relative or absolute path to font file.
+        Returns
+        =======
+        :class:`bool`
+                True means it worked without any error.
+                False means there is a Unknow Error
+        Examples
+        --------
+        >>> register_font("/home/roboto.tff")
+        1
+        Raises
+        ------
+        AssertionError
+            Font is missing.
+        """
+        a=Path(font_path)
+        assert a.exists(), f"font doesn't exists at {a.absolute()}"
+        font_path = str(a.absolute())
+        font_path_bytes=font_path.encode('ascii')
+        cdef const unsigned char* fontPath = font_path_bytes
+        fontAddStatus = FcConfigAppFontAddFile(FcConfigGetCurrent(), fontPath)
+        if fontAddStatus:
+            return True
+        else:
+            return False

--- a/manimpango/cmanimpango.pyx
+++ b/manimpango/cmanimpango.pyx
@@ -367,7 +367,7 @@ IF UNAME_SYSNAME == "Linux":
         =======
         :class:`bool`
                 True means it worked without any error.
-                False means there is a Unknow Error
+                False means there was an unknown error
         Examples
         --------
         >>> register_font("/home/roboto.tff")

--- a/setup.py
+++ b/setup.py
@@ -58,9 +58,16 @@ def get_library_config(name):
     return known
 
 
+def update_dict(dict1, dict2):
+    for key in dict2:
+        dict2[key] = list(set(dict1[key] + dict2[key]))
+    return dict2
+
+
 ext = ".pyx" if USE_CYTHON else ".c"
 base_file = Path(__file__).parent / "manimpango"
 returns = get_library_config("pangocairo")
+returns = update_dict(returns, get_library_config("pangofc"))
 ext_modules = [
     Extension(
         "manimpango.cmanimpango",


### PR DESCRIPTION
For now only for Linux, because they use font config as default backend for the font. While on Windows and Mac, win32 API and CoreText are used respectively. 
We can force Pango to use `fontconfig` backend as default on other OS also, but because of https://gitlab.gnome.org/GNOME/pango/-/issues/523, I am reluctant to do so. Also, this means that Cairo should be compiled with `fontconfig` enabled for this work. Windows users will face no issues in this because the binaries are compiled with fontconfig enabled, but I am not sure on Mac's brew, maybe @PhilippImhof know?
For now, it is conditionally compiled only for Linux. Other OS can't use it for now until we decide over here, whether to force fontconfig usage.
