### PR TITLE
Same line length for flake and black

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -2,3 +2,6 @@
 license_files =
    LICENSE
    LICENSE.win32
+
+[flake8]
+max-line-length = 88


### PR DESCRIPTION
`flake8` and `black` should not enforce different line lengths, as this leads to conflicts.