### PR TITLE
Fix Macos wheels

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
       CIBW_BUILD: cp36-${{ matrix.platform_id }} cp37-${{ matrix.platform_id }} cp38-${{ matrix.platform_id }} cp39-${{ matrix.platform_id }}
       CIBW_SKIP: pp* cp35
       CIBW_BEFORE_BUILD_LINUX: "source packing/build_pango.sh && pip install cython && cd manimpango && cythonize cmanimpango.pyx -3 -k -f && cd ../ && pip install ."
-      CIBW_BEFORE_BUILD_MACOS: "source packing/build_pango_mac.sh && pip install cython && cd manimpango && cythonize cmanimpango.pyx -3 -k -f && cd ../ && pip install . && pkg-config --libs pango"
+      CIBW_BEFORE_BUILD_MACOS: "brew list && source packing/build_pango_mac.sh && pip install cython && cd manimpango && cythonize cmanimpango.pyx -3 -k -f && cd ../ && pip install . && pkg-config --libs pango"
       CIBW_BEFORE_BUILD_WINDOWS: "pip install cython && python packing/download_dlls.py && cd manimpango && cythonize cmanimpango.pyx -3 -k -f && cd ../ && pkg-config --libs pango && pip install ."
       CIBW_ENVIRONMENT_WINDOWS: "PKG_CONFIG_PATH='C:\\cibw\\vendor\\lib\\pkgconfig'"
       CIBW_ENVIRONMENT_MACOS: "PKG_CONFIG_PATH='/Users/runner/pangobuild/lib/pkgconfig'"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
       CIBW_BUILD: cp36-${{ matrix.platform_id }} cp37-${{ matrix.platform_id }} cp38-${{ matrix.platform_id }} cp39-${{ matrix.platform_id }}
       CIBW_SKIP: pp* cp35
       CIBW_BEFORE_BUILD_LINUX: "source packing/build_pango.sh && pip install cython && cd manimpango && cythonize cmanimpango.pyx -3 -k -f && cd ../ && pip install ."
-      CIBW_BEFORE_BUILD_MACOS: "brew uninstall --ignore-dependencies fontconfig && source packing/build_pango_mac.sh && pip install cython && cd manimpango && cythonize cmanimpango.pyx -3 -k -f && cd ../ && pip install ."
+      CIBW_BEFORE_BUILD_MACOS: "brew uninstall --ignore-dependencies gettext && brew uninstall --ignore-dependencies fontconfig && source packing/build_pango_mac.sh && pip install cython && cd manimpango && cythonize cmanimpango.pyx -3 -k -f && cd ../ && pip install ."
       CIBW_BEFORE_BUILD_WINDOWS: "pip install cython && python packing/download_dlls.py && cd manimpango && cythonize cmanimpango.pyx -3 -k -f && cd ../ && pkg-config --libs pango && pip install ."
       CIBW_ENVIRONMENT_WINDOWS: "PKG_CONFIG_PATH='C:\\cibw\\vendor\\lib\\pkgconfig'"
       CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: python packing/inject-dlls.py {wheel} {dest_dir} C:\cibw\vendor\bin

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,6 @@ jobs:
       CIBW_BEFORE_BUILD_MACOS: "source packing/build_pango_mac.sh && pip install cython && cd manimpango && cythonize cmanimpango.pyx -3 -k -f && cd ../ && pip install ."
       CIBW_BEFORE_BUILD_WINDOWS: "pip install cython && python packing/download_dlls.py && cd manimpango && cythonize cmanimpango.pyx -3 -k -f && cd ../ && pkg-config --libs pango && pip install ."
       CIBW_ENVIRONMENT_WINDOWS: "PKG_CONFIG_PATH='C:\\cibw\\vendor\\lib\\pkgconfig'"
-      CIBW_REPAIR_WHEEL_COMMAND_MACOS: ''
       CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: python packing/inject-dlls.py {wheel} {dest_dir} C:\cibw\vendor\bin
       CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
       CIBW_MANYLINUX_I686_IMAGE: manylinux2014

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,7 @@ jobs:
       CIBW_TEST_REQUIRES: pytest Cython
       CIBW_TEST_COMMAND: "bash {project}/packing/test_wheels.sh {project}"
       CIBW_BUILD_VERBOSITY: 2
-      CIBW_REPAIR_WHEEL_COMMAND: delocate-listdeps {wheel} && delocate-wheel --require-archs x86_64 -v -w {dest_dir} {wheel}
+      CIBW_REPAIR_WHEEL_COMMAND_MACOS: delocate-listdeps {wheel} && delocate-wheel --require-archs x86_64 -v -w {dest_dir} {wheel}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - macos-wheels
   release:
     types: [created]
 
@@ -14,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-18.04, macos-latest, windows-2016]
+        os: [macos-latest]
         bitness: [32, 64]
         include:
           # Run 32 and 64 bit version in parallel for Linux and Windows

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-18.04, macos-10.13, windows-2016]
+        os: [ubuntu-18.04, macos-latest, windows-2016]
         bitness: [32, 64]
         include:
           # Run 32 and 64 bit version in parallel for Linux and Windows
@@ -31,11 +31,11 @@ jobs:
           - os: ubuntu-18.04
             bitness: 32
             platform_id: manylinux_i686
-          - os: macos-10.13
+          - os: macos-latest
             bitness: 64
             platform_id: macosx_x86_64
         exclude:
-          - os: macos-10.13
+          - os: macos-latest
             bitness: 32
     env:
       CIBW_BUILD: cp36-${{ matrix.platform_id }} cp37-${{ matrix.platform_id }} cp38-${{ matrix.platform_id }} cp39-${{ matrix.platform_id }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,6 +44,7 @@ jobs:
       CIBW_BEFORE_BUILD_MACOS: "source packing/build_pango_mac.sh && pip install cython && cd manimpango && cythonize cmanimpango.pyx -3 -k -f && cd ../ && pip install ."
       CIBW_BEFORE_BUILD_WINDOWS: "pip install cython && python packing/download_dlls.py && cd manimpango && cythonize cmanimpango.pyx -3 -k -f && cd ../ && pkg-config --libs pango && pip install ."
       CIBW_ENVIRONMENT_WINDOWS: "PKG_CONFIG_PATH='C:\\cibw\\vendor\\lib\\pkgconfig'"
+      CIBW_REPAIR_WHEEL_COMMAND_MACOS: ''
       CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: python packing/inject-dlls.py {wheel} {dest_dir} C:\cibw\vendor\bin
       CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
       CIBW_MANYLINUX_I686_IMAGE: manylinux2014
@@ -62,7 +63,7 @@ jobs:
         continue-on-error: true
         shell: bash
         run: |
-          python -m pip install cibuildwheel==1.6.4
+          python -m pip install cibuildwheel==1.8.0
           echo "$event_name"
 
       - name: Build wheels(Windows)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,7 @@ jobs:
       CIBW_TEST_REQUIRES: pytest Cython
       CIBW_TEST_COMMAND: "bash {project}/packing/test_wheels.sh {project}"
       CIBW_BUILD_VERBOSITY: 2
-      CIBW_REPAIR_WHEEL_COMMAND_MACOS: delocate-listdeps --all {wheel} && delocate-wheel --require-archs x86_64 -v -w {dest_dir} {wheel}
+      CIBW_REPAIR_WHEEL_COMMAND_MACOS: delocate-listdeps --depending {wheel} && delocate-wheel --require-archs x86_64 -v -w {dest_dir} {wheel}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
       CIBW_BUILD: cp36-${{ matrix.platform_id }} cp37-${{ matrix.platform_id }} cp38-${{ matrix.platform_id }} cp39-${{ matrix.platform_id }}
       CIBW_SKIP: pp* cp35
       CIBW_BEFORE_BUILD_LINUX: "source packing/build_pango.sh && pip install cython && cd manimpango && cythonize cmanimpango.pyx -3 -k -f && cd ../ && pip install ."
-      CIBW_BEFORE_BUILD_MACOS: "source packing/build_pango_mac.sh && pip install cython && cd manimpango && cythonize cmanimpango.pyx -3 -k -f && cd ../ && pip install ."
+      CIBW_BEFORE_BUILD_MACOS: "brew uninstall --ignore-dependencies fontconfig && source packing/build_pango_mac.sh && pip install cython && cd manimpango && cythonize cmanimpango.pyx -3 -k -f && cd ../ && pip install ."
       CIBW_BEFORE_BUILD_WINDOWS: "pip install cython && python packing/download_dlls.py && cd manimpango && cythonize cmanimpango.pyx -3 -k -f && cd ../ && pkg-config --libs pango && pip install ."
       CIBW_ENVIRONMENT_WINDOWS: "PKG_CONFIG_PATH='C:\\cibw\\vendor\\lib\\pkgconfig'"
       CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: python packing/inject-dlls.py {wheel} {dest_dir} C:\cibw\vendor\bin

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
       CIBW_BUILD: cp36-${{ matrix.platform_id }} cp37-${{ matrix.platform_id }} cp38-${{ matrix.platform_id }} cp39-${{ matrix.platform_id }}
       CIBW_SKIP: pp* cp35
       CIBW_BEFORE_BUILD_LINUX: "source packing/build_pango.sh && pip install cython && cd manimpango && cythonize cmanimpango.pyx -3 -k -f && cd ../ && pip install ."
-      CIBW_BEFORE_BUILD_MACOS: "brew list && source packing/build_pango_mac.sh && pip install cython && cd manimpango && cythonize cmanimpango.pyx -3 -k -f && cd ../ && pip install . && pkg-config --libs pango"
+      CIBW_BEFORE_BUILD_MACOS: "brew list --formula && source packing/build_pango_mac.sh && pip install cython && cd manimpango && cythonize cmanimpango.pyx -3 -k -f && cd ../ && pip install . && pkg-config --libs pango"
       CIBW_BEFORE_BUILD_WINDOWS: "pip install cython && python packing/download_dlls.py && cd manimpango && cythonize cmanimpango.pyx -3 -k -f && cd ../ && pkg-config --libs pango && pip install ."
       CIBW_ENVIRONMENT_WINDOWS: "PKG_CONFIG_PATH='C:\\cibw\\vendor\\lib\\pkgconfig'"
       CIBW_ENVIRONMENT_MACOS: "PKG_CONFIG_PATH='/Users/runner/pangobuild/lib/pkgconfig'"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,27 +16,27 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest]
-        bitness: [32, 64]
-        include:
-          # Run 32 and 64 bit version in parallel for Linux and Windows
-          - os: windows-2016
-            bitness: 64
-            platform_id: win_amd64
-          - os: windows-2016
-            bitness: 32
-            platform_id: win32
-          - os: ubuntu-18.04
-            bitness: 64
-            platform_id: manylinux_x86_64
-          - os: ubuntu-18.04
-            bitness: 32
-            platform_id: manylinux_i686
-          - os: macos-latest
-            bitness: 64
-            platform_id: macosx_x86_64
-        exclude:
-          - os: macos-latest
-            bitness: 32
+        bitness: [64]
+        # include:
+        #   # Run 32 and 64 bit version in parallel for Linux and Windows
+        #   - os: windows-2016
+        #     bitness: 64
+        #     platform_id: win_amd64
+        #   - os: windows-2016
+        #     bitness: 32
+        #     platform_id: win32
+        #   - os: ubuntu-18.04
+        #     bitness: 64
+        #     platform_id: manylinux_x86_64
+        #   - os: ubuntu-18.04
+        #     bitness: 32
+        #     platform_id: manylinux_i686
+        #   - os: macos-latest
+        #     bitness: 64
+        #     platform_id: macosx_x86_64
+        # exclude:
+        #   - os: macos-latest
+        #     bitness: 32
     env:
       CIBW_BUILD: cp36-${{ matrix.platform_id }} cp37-${{ matrix.platform_id }} cp38-${{ matrix.platform_id }} cp39-${{ matrix.platform_id }}
       CIBW_SKIP: pp* cp35

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,11 +31,11 @@ jobs:
           - os: ubuntu-18.04
             bitness: 32
             platform_id: manylinux_i686
-          - os: macos-latest
+          - os: macos-10.13
             bitness: 64
             platform_id: macosx_x86_64
         exclude:
-          - os: macos-latest
+          - os: macos-10.13
             bitness: 32
     env:
       CIBW_BUILD: cp36-${{ matrix.platform_id }} cp37-${{ matrix.platform_id }} cp38-${{ matrix.platform_id }} cp39-${{ matrix.platform_id }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,6 +49,7 @@ jobs:
       CIBW_MANYLINUX_I686_IMAGE: manylinux2014
       CIBW_TEST_REQUIRES: pytest Cython
       CIBW_TEST_COMMAND: "bash {project}/packing/test_wheels.sh {project}"
+      CIBW_BUILD_VERBOSITY: 2
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - macos-wheels
   release:
     types: [created]
 
@@ -41,7 +40,7 @@ jobs:
       CIBW_BUILD: cp36-${{ matrix.platform_id }} cp37-${{ matrix.platform_id }} cp38-${{ matrix.platform_id }} cp39-${{ matrix.platform_id }}
       CIBW_SKIP: pp* cp35
       CIBW_BEFORE_BUILD_LINUX: "source packing/build_pango.sh && pip install cython && cd manimpango && cythonize cmanimpango.pyx -3 -k -f && cd ../ && pip install ."
-      CIBW_BEFORE_BUILD_MACOS: "brew list --formula && source packing/build_pango_mac.sh && pip install cython && cd manimpango && cythonize cmanimpango.pyx -3 -k -f && cd ../ && pip install . && pkg-config --libs pango"
+      CIBW_BEFORE_BUILD_MACOS: "source packing/build_pango_mac.sh && pip install cython && cd manimpango && cythonize cmanimpango.pyx -3 -k -f && cd ../ && pip install . && pkg-config --libs pango"
       CIBW_BEFORE_BUILD_WINDOWS: "pip install cython && python packing/download_dlls.py && cd manimpango && cythonize cmanimpango.pyx -3 -k -f && cd ../ && pkg-config --libs pango && pip install ."
       CIBW_ENVIRONMENT_WINDOWS: "PKG_CONFIG_PATH='C:\\cibw\\vendor\\lib\\pkgconfig'"
       CIBW_ENVIRONMENT_MACOS: "PKG_CONFIG_PATH='/Users/runner/pangobuild/lib/pkgconfig'"
@@ -51,7 +50,6 @@ jobs:
       CIBW_TEST_REQUIRES: pytest Cython
       CIBW_TEST_COMMAND: "bash {project}/packing/test_wheels.sh {project}"
       CIBW_BUILD_VERBOSITY: 2
-      CIBW_REPAIR_WHEEL_COMMAND_MACOS: delocate-listdeps --depending {wheel} && delocate-wheel --require-archs x86_64 -v -w {dest_dir} {wheel}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
       CIBW_BUILD: cp36-${{ matrix.platform_id }} cp37-${{ matrix.platform_id }} cp38-${{ matrix.platform_id }} cp39-${{ matrix.platform_id }}
       CIBW_SKIP: pp* cp35
       CIBW_BEFORE_BUILD_LINUX: "source packing/build_pango.sh && pip install cython && cd manimpango && cythonize cmanimpango.pyx -3 -k -f && cd ../ && pip install ."
-      CIBW_BEFORE_BUILD_MACOS: "brew uninstall --ignore-dependencies gettext && brew uninstall --ignore-dependencies fontconfig && source packing/build_pango_mac.sh && pip install cython && cd manimpango && cythonize cmanimpango.pyx -3 -k -f && cd ../ && pip install ."
+      CIBW_BEFORE_BUILD_MACOS: "source packing/build_pango_mac.sh && pip install cython && cd manimpango && cythonize cmanimpango.pyx -3 -k -f && cd ../ && pip install ."
       CIBW_BEFORE_BUILD_WINDOWS: "pip install cython && python packing/download_dlls.py && cd manimpango && cythonize cmanimpango.pyx -3 -k -f && cd ../ && pkg-config --libs pango && pip install ."
       CIBW_ENVIRONMENT_WINDOWS: "PKG_CONFIG_PATH='C:\\cibw\\vendor\\lib\\pkgconfig'"
       CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: python packing/inject-dlls.py {wheel} {dest_dir} C:\cibw\vendor\bin

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,28 +15,28 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest]
-        bitness: [64]
-        # include:
-        #   # Run 32 and 64 bit version in parallel for Linux and Windows
-        #   - os: windows-2016
-        #     bitness: 64
-        #     platform_id: win_amd64
-        #   - os: windows-2016
-        #     bitness: 32
-        #     platform_id: win32
-        #   - os: ubuntu-18.04
-        #     bitness: 64
-        #     platform_id: manylinux_x86_64
-        #   - os: ubuntu-18.04
-        #     bitness: 32
-        #     platform_id: manylinux_i686
-        #   - os: macos-latest
-        #     bitness: 64
-        #     platform_id: macosx_x86_64
-        # exclude:
-        #   - os: macos-latest
-        #     bitness: 32
+        os: [ubuntu-18.04, macos-latest, windows-2016]
+        bitness: [32, 64]
+        include:
+          # Run 32 and 64 bit version in parallel for Linux and Windows
+          - os: windows-2016
+            bitness: 64
+            platform_id: win_amd64
+          - os: windows-2016
+            bitness: 32
+            platform_id: win32
+          - os: ubuntu-18.04
+            bitness: 64
+            platform_id: manylinux_x86_64
+          - os: ubuntu-18.04
+            bitness: 32
+            platform_id: manylinux_i686
+          - os: macos-latest
+            bitness: 64
+            platform_id: macosx_x86_64
+        exclude:
+          - os: macos-latest
+            bitness: 32
     env:
       CIBW_BUILD: cp36-${{ matrix.platform_id }} cp37-${{ matrix.platform_id }} cp38-${{ matrix.platform_id }} cp39-${{ matrix.platform_id }}
       CIBW_SKIP: pp* cp35

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
       CIBW_BUILD: cp36-${{ matrix.platform_id }} cp37-${{ matrix.platform_id }} cp38-${{ matrix.platform_id }} cp39-${{ matrix.platform_id }}
       CIBW_SKIP: pp* cp35
       CIBW_BEFORE_BUILD_LINUX: "source packing/build_pango.sh && pip install cython && cd manimpango && cythonize cmanimpango.pyx -3 -k -f && cd ../ && pip install ."
-      CIBW_BEFORE_BUILD_MACOS: "brew reinstall pango && brew reinstall cairo && pip install cython && cd manimpango && cythonize cmanimpango.pyx -3 -k -f && cd ../ && pip install ."
+      CIBW_BEFORE_BUILD_MACOS: "source packing/build_pango_mac.sh && pip install cython && cd manimpango && cythonize cmanimpango.pyx -3 -k -f && cd ../ && pip install ."
       CIBW_BEFORE_BUILD_WINDOWS: "pip install cython && python packing/download_dlls.py && cd manimpango && cythonize cmanimpango.pyx -3 -k -f && cd ../ && pkg-config --libs pango && pip install ."
       CIBW_ENVIRONMENT_WINDOWS: "PKG_CONFIG_PATH='C:\\cibw\\vendor\\lib\\pkgconfig'"
       CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: python packing/inject-dlls.py {wheel} {dest_dir} C:\cibw\vendor\bin

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,6 +50,7 @@ jobs:
       CIBW_TEST_REQUIRES: pytest Cython
       CIBW_TEST_COMMAND: "bash {project}/packing/test_wheels.sh {project}"
       CIBW_BUILD_VERBOSITY: 2
+      CIBW_REPAIR_WHEEL_COMMAND: delocate-listdeps {wheel} && delocate-wheel --require-archs x86_64 -v -w {dest_dir} {wheel}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,10 +41,10 @@ jobs:
       CIBW_BUILD: cp36-${{ matrix.platform_id }} cp37-${{ matrix.platform_id }} cp38-${{ matrix.platform_id }} cp39-${{ matrix.platform_id }}
       CIBW_SKIP: pp* cp35
       CIBW_BEFORE_BUILD_LINUX: "source packing/build_pango.sh && pip install cython && cd manimpango && cythonize cmanimpango.pyx -3 -k -f && cd ../ && pip install ."
-      CIBW_BEFORE_BUILD_MACOS: "source packing/build_pango_mac.sh && pip install cython && cd manimpango && cythonize cmanimpango.pyx -3 -k -f && cd ../ && pip install ."
+      CIBW_BEFORE_BUILD_MACOS: "source packing/build_pango_mac.sh && pip install cython && cd manimpango && cythonize cmanimpango.pyx -3 -k -f && cd ../ && pip install . && pkg-config --libs pango"
       CIBW_BEFORE_BUILD_WINDOWS: "pip install cython && python packing/download_dlls.py && cd manimpango && cythonize cmanimpango.pyx -3 -k -f && cd ../ && pkg-config --libs pango && pip install ."
       CIBW_ENVIRONMENT_WINDOWS: "PKG_CONFIG_PATH='C:\\cibw\\vendor\\lib\\pkgconfig'"
-      CIBW_ENVIRONMENT_MACOS: "PKG_CONFIG_PATH='$HOME/pangobuild/lib/pkgconfig'"
+      CIBW_ENVIRONMENT_MACOS: "PKG_CONFIG_PATH='/Users/runner/pangobuild/lib/pkgconfig'"
       CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: python packing/inject-dlls.py {wheel} {dest_dir} C:\cibw\vendor\bin
       CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
       CIBW_MANYLINUX_I686_IMAGE: manylinux2014

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,7 @@ jobs:
       CIBW_TEST_REQUIRES: pytest Cython
       CIBW_TEST_COMMAND: "bash {project}/packing/test_wheels.sh {project}"
       CIBW_BUILD_VERBOSITY: 2
-      CIBW_REPAIR_WHEEL_COMMAND_MACOS: delocate-listdeps {wheel} && delocate-wheel --require-archs x86_64 -v -w {dest_dir} {wheel}
+      CIBW_REPAIR_WHEEL_COMMAND_MACOS: delocate-listdeps {wheel} && TMPDIR=/var/tmp delocate-wheel --require-archs x86_64 -v -w {dest_dir} {wheel}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,6 +44,7 @@ jobs:
       CIBW_BEFORE_BUILD_MACOS: "source packing/build_pango_mac.sh && pip install cython && cd manimpango && cythonize cmanimpango.pyx -3 -k -f && cd ../ && pip install ."
       CIBW_BEFORE_BUILD_WINDOWS: "pip install cython && python packing/download_dlls.py && cd manimpango && cythonize cmanimpango.pyx -3 -k -f && cd ../ && pkg-config --libs pango && pip install ."
       CIBW_ENVIRONMENT_WINDOWS: "PKG_CONFIG_PATH='C:\\cibw\\vendor\\lib\\pkgconfig'"
+      CIBW_ENVIRONMENT_MACOS: "PKG_CONFIG_PATH='$HOME/pangobuild/lib/pkgconfig'"
       CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: python packing/inject-dlls.py {wheel} {dest_dir} C:\cibw\vendor\bin
       CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
       CIBW_MANYLINUX_I686_IMAGE: manylinux2014

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,7 @@ jobs:
       CIBW_TEST_REQUIRES: pytest Cython
       CIBW_TEST_COMMAND: "bash {project}/packing/test_wheels.sh {project}"
       CIBW_BUILD_VERBOSITY: 2
-      CIBW_REPAIR_WHEEL_COMMAND_MACOS: delocate-listdeps {wheel} && TMPDIR=/var/tmp delocate-wheel --require-archs x86_64 -v -w {dest_dir} {wheel}
+      CIBW_REPAIR_WHEEL_COMMAND_MACOS: delocate-listdeps --all {wheel} && delocate-wheel --require-archs x86_64 -v -w {dest_dir} {wheel}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-18.04, macos-latest, windows-2016]
+        os: [ubuntu-18.04, macos-10.13, windows-2016]
         bitness: [32, 64]
         include:
           # Run 32 and 64 bit version in parallel for Linux and Windows

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
       CIBW_BUILD: cp36-${{ matrix.platform_id }} cp37-${{ matrix.platform_id }} cp38-${{ matrix.platform_id }} cp39-${{ matrix.platform_id }}
       CIBW_SKIP: pp* cp35
       CIBW_BEFORE_BUILD_LINUX: "source packing/build_pango.sh && pip install cython && cd manimpango && cythonize cmanimpango.pyx -3 -k -f && cd ../ && pip install ."
-      CIBW_BEFORE_BUILD_MACOS: "brew install pango && pkg-config --libs pango && source packing/build_pango_mac.sh && pip install cython && cd manimpango && cythonize cmanimpango.pyx -3 -k -f && cd ../ && pip install ."
+      CIBW_BEFORE_BUILD_MACOS: "source packing/build_pango_mac.sh && pip install cython && cd manimpango && cythonize cmanimpango.pyx -3 -k -f && cd ../ && pip install ."
       CIBW_BEFORE_BUILD_WINDOWS: "pip install cython && python packing/download_dlls.py && cd manimpango && cythonize cmanimpango.pyx -3 -k -f && cd ../ && pkg-config --libs pango && pip install ."
       CIBW_ENVIRONMENT_WINDOWS: "PKG_CONFIG_PATH='C:\\cibw\\vendor\\lib\\pkgconfig'"
       CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: python packing/inject-dlls.py {wheel} {dest_dir} C:\cibw\vendor\bin

--- a/packing/build_pango_mac.sh
+++ b/packing/build_pango_mac.sh
@@ -56,6 +56,10 @@ echo "Installing Meson and Ninja"
 pip3 install -U meson ninja
 echo "::endgroup::"
 
+echo "::group::Removing the things from brew"
+brew uninstall brotli
+brew uninstall pcre
+echo "::endgroup::"
 
 echo "::group::Building and Install proxy-libintl"
 meson setup --buildtype=release libintlbuilddir proxy-libintl
@@ -99,6 +103,14 @@ make install
 cd ..
 echo "::endgroup::"
 
+echo "::group::Building and Install Libpng"
+cd libpng
+./configure --prefix=$PREFIX
+make
+make install
+cd ..
+echo "::endgroup::"
+
 echo "::group::Building and Installing Freetype"
 cd freetype
 ./configure --without-harfbuzz --prefix=$PREFIX
@@ -114,13 +126,6 @@ meson compile -C fontconfig_builddir
 meson install -C fontconfig_builddir
 echo "::endgroup::"
 
-echo "::group::Building and Install Libpng"
-cd libpng
-./configure --prefix=$PREFIX
-make
-make install
-cd ..
-echo "::endgroup::"
 
 echo "::group::Building and Installing Pixman"
 cd pixman

--- a/packing/build_pango_mac.sh
+++ b/packing/build_pango_mac.sh
@@ -44,11 +44,13 @@ python $FILE_PATH/packing/download_and_extract.py "https://mirrors.kernel.org/gn
 python $FILE_PATH/packing/download_and_extract.py "https://downloads.sourceforge.net/project/libpng/libpng16/${LIBPNG_VERSION}/libpng-${LIBPNG_VERSION}.tar.xz" libpng
 python $FILE_PATH/packing/download_and_extract.py "https://github.com/harfbuzz/harfbuzz/releases/download/${HARFBUZZ_VERSION}/harfbuzz-${HARFBUZZ_VERSION}.tar.xz" harfbuzz
 python $FILE_PATH/packing/download_and_extract.py "https://zlib.net/fossils/zlib-${ZLIB_VERSION}.tar.gz" zlib
-python $FILE_PATH/packing/download_and_extract.py "https://github.com/google/brotli/archive/v${BROTLI_VERSION}.tar.gz" brotli
 python $FILE_PATH/packing/download_and_extract.py "https://ftp.pcre.org/pub/pcre/pcre-${PCRE_VERSION}.tar.bz2" pcre
 curl -L "https://github.com/frida/proxy-libintl/archive/0.1.tar.gz" -o 0.1.tar.gz
 tar -xf 0.1.tar.gz
 mv proxy-libintl-0.1 proxy-libintl
+curl -L "https://github.com/google/brotli/archive/v${BROTLI_VERSION}.tar.gz" -o brotli${BROTLI_VERSION}.tar.gz
+tar -xf brotli${BROTLI_VERSION}.tar.gz
+mv brotli-${BROTLI_VERSION} brotli
 python -m pip uninstall -y requests
 
 echo "::endgroup::"

--- a/packing/build_pango_mac.sh
+++ b/packing/build_pango_mac.sh
@@ -91,7 +91,7 @@ echo "::endgroup::"
 
 echo "::group::Building and Install Zlib"
 cd zlib
-./configure --prefix=$PREFIX
+./configure --prefix=$PREFIX --enable-static
 make
 make install
 cd ..

--- a/packing/build_pango_mac.sh
+++ b/packing/build_pango_mac.sh
@@ -59,7 +59,7 @@ cd ..
 echo "::endgroup::"
 
 echo "::group::Building and Install Glib"
-meson setup --prefix=/usr --buildtype=release -Dselinux=disabled -Dlibmount=false glib_builddir glib
+meson setup --prefix=/usr --buildtype=release -Dselinux=disabled -Dlibmount=enabled glib_builddir glib
 meson compile -C glib_builddir
 meson install -C glib_builddir
 echo "::endgroup::"

--- a/packing/build_pango_mac.sh
+++ b/packing/build_pango_mac.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+# build and install pango
+set -e
+
+PANGO_VERSION=1.48.0
+GLIB_VERSION=2.66.4
+FRIBIDI_VERSION=1.0.10
+CAIRO_VERSION=1.17.4
+PIXMAN_VERSION=0.40.0
+FREETYPE_VERSION=2.10.4
+FONTCONFIG_VERSION=2.13.93
+EXPANT_VERSION=2.2.10 # TODO: change url to use this version
+GPERF_VERSION=3.1
+LIBPNG_VERSION=1.6.37
+HARFBUZZ_VERSION=2.7.3
+ZLIB_VERSION=1.2.11
+
+FILE_PATH="`dirname \"$0\"`"
+FILE_PATH="`( cd \"$FILE_PATH\" && pwd )`"
+if [ -z "$FILE_PATH" ] ; then
+  exit 1
+fi
+
+cd $TMP
+if [ -d "$PWD/pango" ] ; then
+  echo "Skipping Build"
+  exit 0
+fi
+
+mkdir pango
+cd pango
+echo "::group::Downloading Files"
+
+python -m pip install requests
+python $FILE_PATH/packing/download_and_extract.py "http://download.gnome.org/sources/pango/${PANGO_VERSION%.*}/pango-${PANGO_VERSION}.tar.xz" pango
+python $FILE_PATH/packing/download_and_extract.py "http://download.gnome.org/sources/glib/${GLIB_VERSION%.*}/glib-${GLIB_VERSION}.tar.xz" glib
+python $FILE_PATH/packing/download_and_extract.py "https://github.com/fribidi/fribidi/releases/download/v${FRIBIDI_VERSION}/fribidi-${FRIBIDI_VERSION}.tar.xz" fribidi
+python $FILE_PATH/packing/download_and_extract.py "https://cairographics.org/snapshots/cairo-${CAIRO_VERSION}.tar.xz" cairo
+python $FILE_PATH/packing/download_and_extract.py "https://cairographics.org/releases/pixman-${PIXMAN_VERSION}.tar.gz" pixman
+python $FILE_PATH/packing/download_and_extract.py "https://www.freedesktop.org/software/fontconfig/release/fontconfig-${FONTCONFIG_VERSION}.tar.xz" fontconfig
+python $FILE_PATH/packing/download_and_extract.py "https://download.savannah.gnu.org/releases/freetype/freetype-${FREETYPE_VERSION}.tar.gz" freetype
+python $FILE_PATH/packing/download_and_extract.py "https://github.com/libexpat/libexpat/releases/download/R_2_2_10/expat-2.2.10.tar.xz" expat
+python $FILE_PATH/packing/download_and_extract.py "https://mirrors.kernel.org/gnu/gperf/gperf-${GPERF_VERSION}.tar.gz" gperf
+python $FILE_PATH/packing/download_and_extract.py "https://downloads.sourceforge.net/project/libpng/libpng16/${LIBPNG_VERSION}/libpng-${LIBPNG_VERSION}.tar.xz" libpng
+python $FILE_PATH/packing/download_and_extract.py "https://github.com/harfbuzz/harfbuzz/releases/download/${HARFBUZZ_VERSION}/harfbuzz-${HARFBUZZ_VERSION}.tar.xz" harfbuzz
+python $FILE_PATH/packing/download_and_extract.py "https://zlib.net/fossils/zlib-${ZLIB_VERSION}.tar.gz" zlib
+python -m pip uninstall -y requests
+
+echo "::endgroup::"
+
+
+echo "::group::Install Meson"
+echo "Installing Meson and Ninja"
+pip3 install -U meson ninja
+echo "::endgroup::"
+
+echo "::group::Building and Install Zlib"
+cd zlib
+./configure
+make
+make install
+cd ..
+echo "::endgroup::"
+
+echo "::group::Building and Install Glib"
+meson setup --prefix=/usr --buildtype=release -Dselinux=disabled -Dlibmount=false glib_builddir glib
+meson compile -C glib_builddir
+meson install -C glib_builddir
+echo "::endgroup::"
+
+echo "::group::Building and Install Fribidi"
+meson setup --prefix=/usr --buildtype=release fribidi_builddir fribidi
+meson compile -C fribidi_builddir
+meson install -C fribidi_builddir
+echo "::endgroup::"
+
+echo "::group::Building and Installing Gperf"
+cd gperf
+./configure
+make
+make install
+cd ..
+echo "::endgroup::"
+
+echo "::group::Building and Installing Expat"
+cd expat
+./configure
+make
+make install
+cd ..
+echo "::endgroup::"
+
+echo "::group::Building and Installing Freetype"
+cd freetype
+./configure --without-harfbuzz
+make
+make install
+cd ..
+echo "::endgroup::"
+
+echo "::group::Building and Install Fontconfig"
+meson setup --prefix=/usr --buildtype=release -Ddoc=disabled -Dtests=disabled -Dtools=disabled fontconfig_builddir fontconfig
+meson compile -C fontconfig_builddir
+meson install -C fontconfig_builddir
+echo "::endgroup::"
+
+echo "::group::Building and Install Libpng"
+cd libpng
+./configure
+make
+make install
+cd ..
+echo "::endgroup::"
+
+echo "::group::Building and Installing Pixman"
+cd pixman
+./configure
+make
+make install
+cd ..
+echo "::endgroup::"
+
+echo "::group::Building and Installing Cairo"
+cd cairo
+./configure --enable-fontconfig --enable-freetype
+make
+make install
+cd ..
+echo "::endgroup::"
+
+echo "::group::Building and Installing Harfbuzz"
+meson setup --prefix=/usr --buildtype=release -Dtests=disabled -Ddocs=disabled harfbuzz_builddir harfbuzz
+meson compile -C harfbuzz_builddir
+meson install -C harfbuzz_builddir
+echo "::endgroup::"
+
+echo "::group::Buildling and Installing Pango"
+meson setup --prefix=/usr --buildtype=release -Dintrospection=false pango_builddir pango
+meson compile -C pango_builddir
+meson install -C pango_builddir
+echo "::endgroup::"
+
+cd $FILE_PATH

--- a/packing/build_pango_mac.sh
+++ b/packing/build_pango_mac.sh
@@ -18,7 +18,7 @@ INTLTOOL_VERSION=0.51.0
 
 FILE_PATH=$PWD
 
-cd $TEMP
+cd $TMPDIR
 if [ -d "$PWD/pango" ] ; then
   echo "Skipping Build"
   exit 0

--- a/packing/build_pango_mac.sh
+++ b/packing/build_pango_mac.sh
@@ -62,6 +62,8 @@ echo "::endgroup::"
 
 echo "::group::Building and Install IntlTool"
 cd intltool
+cpan App::cpanminus
+cpanm XML::Parser
 ./configure --disable-silent-rules
 make
 make install

--- a/packing/build_pango_mac.sh
+++ b/packing/build_pango_mac.sh
@@ -52,11 +52,14 @@ echo "Installing Meson and Ninja"
 pip3 install -U meson ninja
 echo "::endgroup::"
 
+export PKG_CONFIG_PATH=/home/pango/lib/pkgconfig
+export LD_LIBRARY_PATH=/home/pango/lib
+
 echo "::group::Building and Install IntlTool"
 cd intltool
 cpan App::cpanminus
 cpan XML::Parser
-./configure --disable-silent-rules
+./configure --disable-silent-rules --prefix=/home/pango
 make
 make install
 cd ..
@@ -64,27 +67,27 @@ echo "::endgroup::"
 
 echo "::group::Building and Install Zlib"
 cd zlib
-./configure
+./configure --prefix=/home/pango
 make
 make install
 cd ..
 echo "::endgroup::"
 
 echo "::group::Building and Install Glib"
-meson setup --prefix=/usr --buildtype=release -Dselinux=disabled -Dlibmount=enabled glib_builddir glib
-#meson compile -C glib_builddir
+meson setup --prefix=/home/pango --buildtype=release -Dselinux=disabled -Dlibmount=enabled glib_builddir glib
+meson compile -C glib_builddir
 meson install -C glib_builddir
 echo "::endgroup::"
 
 echo "::group::Building and Install Fribidi"
-meson setup --prefix=/usr --buildtype=release fribidi_builddir fribidi
+meson setup --prefix=/home/pango --buildtype=release fribidi_builddir fribidi
 meson compile -C fribidi_builddir
 meson install -C fribidi_builddir
 echo "::endgroup::"
 
 echo "::group::Building and Installing Gperf"
 cd gperf
-./configure
+./configure --prefix=/home/pango
 make
 make install
 cd ..
@@ -92,7 +95,7 @@ echo "::endgroup::"
 
 echo "::group::Building and Installing Expat"
 cd expat
-./configure
+./configure --prefix=/home/pango
 make
 make install
 cd ..
@@ -100,14 +103,14 @@ echo "::endgroup::"
 
 echo "::group::Building and Installing Freetype"
 cd freetype
-./configure --without-harfbuzz
+./configure --without-harfbuzz --prefix=/home/pango
 make
 make install
 cd ..
 echo "::endgroup::"
 
 echo "::group::Building and Install Fontconfig"
-meson setup --prefix=/usr --buildtype=release -Ddoc=disabled -Dtests=disabled -Dtools=disabled fontconfig_builddir fontconfig
+meson setup --prefix=/home/pango --buildtype=release -Ddoc=disabled -Dtests=disabled -Dtools=disabled fontconfig_builddir fontconfig
 meson compile -C fontconfig_builddir
 meson install -C fontconfig_builddir
 echo "::endgroup::"
@@ -122,7 +125,7 @@ echo "::endgroup::"
 
 echo "::group::Building and Installing Pixman"
 cd pixman
-./configure
+./configure --prefix=/home/pango
 make
 make install
 cd ..
@@ -130,20 +133,20 @@ echo "::endgroup::"
 
 echo "::group::Building and Installing Cairo"
 cd cairo
-./configure --enable-fontconfig --enable-freetype
+./configure --enable-fontconfig --enable-freetype --prefix=/home/pango
 make
 make install
 cd ..
 echo "::endgroup::"
 
 echo "::group::Building and Installing Harfbuzz"
-meson setup --prefix=/usr --buildtype=release -Dtests=disabled -Ddocs=disabled harfbuzz_builddir harfbuzz
+meson setup --prefix=/home/pango --buildtype=release -Dtests=disabled -Ddocs=disabled harfbuzz_builddir harfbuzz
 meson compile -C harfbuzz_builddir
 meson install -C harfbuzz_builddir
 echo "::endgroup::"
 
 echo "::group::Buildling and Installing Pango"
-meson setup --prefix=/usr --buildtype=release -Dintrospection=false pango_builddir pango
+meson setup --prefix=/home/pango --buildtype=release -Dintrospection=false pango_builddir pango
 meson compile -C pango_builddir
 meson install -C pango_builddir
 echo "::endgroup::"

--- a/packing/build_pango_mac.sh
+++ b/packing/build_pango_mac.sh
@@ -48,6 +48,7 @@ python -m pip uninstall -y requests
 
 echo "::endgroup::"
 
+export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig
 
 echo "::group::Install Meson"
 echo "Installing Meson and Ninja"

--- a/packing/build_pango_mac.sh
+++ b/packing/build_pango_mac.sh
@@ -52,14 +52,6 @@ echo "Installing Meson and Ninja"
 pip3 install -U meson ninja
 echo "::endgroup::"
 
-echo "::group::Building and Install Zlib"
-cd zlib
-./configure
-make
-make install
-cd ..
-echo "::endgroup::"
-
 echo "::group::Building and Install IntlTool"
 cd intltool
 cpan App::cpanminus
@@ -70,9 +62,17 @@ make install
 cd ..
 echo "::endgroup::"
 
+echo "::group::Building and Install Zlib"
+cd zlib
+./configure
+make
+make install
+cd ..
+echo "::endgroup::"
+
 echo "::group::Building and Install Glib"
 meson setup --prefix=/usr --buildtype=release -Dselinux=disabled -Dlibmount=enabled glib_builddir glib
-meson compile -C glib_builddir
+#meson compile -C glib_builddir
 meson install -C glib_builddir
 echo "::endgroup::"
 

--- a/packing/build_pango_mac.sh
+++ b/packing/build_pango_mac.sh
@@ -108,6 +108,7 @@ cd ..
 echo "::endgroup::"
 
 echo "::group::Building and Install Fontconfig"
+rm -rf /usr/local/share/fontconfig/conf.avail
 meson setup --buildtype=release -Ddoc=disabled -Dtests=disabled -Dtools=disabled fontconfig_builddir fontconfig
 meson compile -C fontconfig_builddir
 meson install -C fontconfig_builddir

--- a/packing/build_pango_mac.sh
+++ b/packing/build_pango_mac.sh
@@ -91,7 +91,7 @@ echo "::endgroup::"
 
 echo "::group::Building and Install Zlib"
 cd zlib
-./configure --prefix=$PREFIX --enable-static
+./configure --prefix=$PREFIX
 make
 make install
 cd ..

--- a/packing/build_pango_mac.sh
+++ b/packing/build_pango_mac.sh
@@ -17,9 +17,10 @@ ZLIB_VERSION=1.2.11
 INTLTOOL_VERSION=0.51.0
 
 FILE_PATH=$PWD
+PREFIX=$HOME/pangobuild
 
 cd $TMPDIR
-if [ -d "$PWD/pango" ] ; then
+if [ -d $PREFIX ] ; then
   echo "Skipping Build"
   exit 0
 fi
@@ -47,7 +48,7 @@ mv proxy-libintl-0.1 proxy-libintl
 python -m pip uninstall -y requests
 
 echo "::endgroup::"
-PREFIX=$HOME/pangobuild
+
 export PKG_CONFIG_PATH=$PREFIX/lib/pkgconfig
 
 echo "::group::Install Meson"

--- a/packing/build_pango_mac.sh
+++ b/packing/build_pango_mac.sh
@@ -57,8 +57,9 @@ pip3 install -U meson ninja
 echo "::endgroup::"
 
 echo "::group::Removing the things from brew"
-brew uninstall brotli
-brew uninstall pcre
+brew uninstall --ignore-dependencies brotli
+brew uninstall --ignore-dependencies pcre
+brew uninstall --ignore-dependencies libpng
 echo "::endgroup::"
 
 echo "::group::Building and Install proxy-libintl"

--- a/packing/build_pango_mac.sh
+++ b/packing/build_pango_mac.sh
@@ -63,7 +63,7 @@ echo "::endgroup::"
 echo "::group::Building and Install IntlTool"
 cd intltool
 cpan App::cpanminus
-cpanm XML::Parser
+cpan XML::Parser
 ./configure --disable-silent-rules
 make
 make install

--- a/packing/build_pango_mac.sh
+++ b/packing/build_pango_mac.sh
@@ -15,11 +15,7 @@ LIBPNG_VERSION=1.6.37
 HARFBUZZ_VERSION=2.7.3
 ZLIB_VERSION=1.2.11
 
-FILE_PATH="`dirname \"$0\"`"
-FILE_PATH="`( cd \"$FILE_PATH\" && pwd )`"
-if [ -z "$FILE_PATH" ] ; then
-  exit 1
-fi
+FILE_PATH=$PWD
 
 cd $TMP
 if [ -d "$PWD/pango" ] ; then

--- a/packing/build_pango_mac.sh
+++ b/packing/build_pango_mac.sh
@@ -76,42 +76,41 @@ cd pcre
       --enable-pcre32 \
       --enable-unicode-properties \
       --enable-pcregrep-libz \
-      --enable-pcregrep-libbz2 \
-      --enable-static
+      --enable-pcregrep-libbz2
 make
 make install
 cd ..
 echo "::endgroup::"
 
 echo "::group::Building and Install proxy-libintl"
-meson setup --buildtype=release --default-library=static libintlbuilddir proxy-libintl
+meson setup --buildtype=release libintlbuilddir proxy-libintl
 meson compile -C libintlbuilddir
 meson install -C libintlbuilddir
 echo "::endgroup::"
 
 echo "::group::Building and Install Zlib"
 cd zlib
-./configure --prefix=$PREFIX --enable-static
+./configure --prefix=$PREFIX
 make
 make install
 cd ..
 echo "::endgroup::"
 
 echo "::group::Building and Install Glib"
-meson setup --prefix=$PREFIX --default-library=static --buildtype=release -Dselinux=disabled -Dlibmount=enabled glib_builddir glib
+meson setup --prefix=$PREFIX --buildtype=release -Dselinux=disabled -Dlibmount=enabled glib_builddir glib
 meson compile -C glib_builddir
 meson install -C glib_builddir
 echo "::endgroup::"
 
 echo "::group::Building and Install Fribidi"
-meson setup --prefix=$PREFIX --default-library=static --buildtype=release fribidi_builddir fribidi
+meson setup --prefix=$PREFIX --buildtype=release fribidi_builddir fribidi
 meson compile -C fribidi_builddir
 meson install -C fribidi_builddir
 echo "::endgroup::"
 
 echo "::group::Building and Installing Gperf"
 cd gperf
-./configure --prefix=$PREFIX --enable-static
+./configure --prefix=$PREFIX
 make
 make install
 cd ..
@@ -119,7 +118,7 @@ echo "::endgroup::"
 
 echo "::group::Building and Installing Expat"
 cd expat
-./configure --prefix=$PREFIX --enable-static
+./configure --prefix=$PREFIX
 make
 make install
 cd ..
@@ -127,7 +126,7 @@ echo "::endgroup::"
 
 echo "::group::Building and Install Libpng"
 cd libpng
-./configure --prefix=$PREFIX --enable-static
+./configure --prefix=$PREFIX
 make
 make install
 cd ..
@@ -135,7 +134,7 @@ echo "::endgroup::"
 
 echo "::group::Building and Installing Freetype"
 cd freetype
-./configure --without-harfbuzz --prefix=$PREFIX --enable-static
+./configure --without-harfbuzz --prefix=$PREFIX
 make
 make install
 cd ..
@@ -143,7 +142,7 @@ echo "::endgroup::"
 
 echo "::group::Building and Install Fontconfig"
 rm -rf /usr/local/share/fontconfig/conf.avail
-meson setup --buildtype=release --default-library=static --prefix=$PREFIX --sysconfdir=$HOME -Ddoc=disabled -Dtests=disabled -Dtools=disabled fontconfig_builddir fontconfig
+meson setup --buildtype=release --prefix=$PREFIX --sysconfdir=$HOME -Ddoc=disabled -Dtests=disabled -Dtools=disabled fontconfig_builddir fontconfig
 meson compile -C fontconfig_builddir
 meson install -C fontconfig_builddir
 echo "::endgroup::"
@@ -151,7 +150,7 @@ echo "::endgroup::"
 
 echo "::group::Building and Installing Pixman"
 cd pixman
-./configure --prefix=$PREFIX --enable-static
+./configure --prefix=$PREFIX
 make
 make install
 cd ..
@@ -159,7 +158,7 @@ echo "::endgroup::"
 
 echo "::group::Building and Installing Cairo"
 cd cairo
-./configure --prefix=$PREFIX --enable-static --enable-fontconfig --enable-freetype
+./configure --prefix=$PREFIX --enable-fontconfig --enable-freetype
 make
 make install
 cd ..
@@ -171,13 +170,13 @@ cd ..
 echo "::endgroup::"
 
 echo "::group::Building and Installing Harfbuzz"
-meson setup --prefix=$PREFIX --default-library=static --buildtype=release -Dtests=disabled -Ddocs=disabled -Dgobject=disabled -Dcoretext=enabled -Dfreetype=enabled -Dglib=enabled harfbuzz_builddir harfbuzz
+meson setup --prefix=$PREFIX --buildtype=release -Dtests=disabled -Ddocs=disabled -Dgobject=disabled -Dcoretext=enabled -Dfreetype=enabled -Dglib=enabled harfbuzz_builddir harfbuzz
 meson compile -C harfbuzz_builddir
 meson install -C harfbuzz_builddir
 echo "::endgroup::"
 
 echo "::group::Buildling and Installing Pango"
-meson setup --prefix=$PREFIX --default-library=static --buildtype=release -Dintrospection=disabled pango_builddir pango
+meson setup --prefix=$PREFIX --buildtype=release -Dintrospection=disabled pango_builddir pango
 meson compile -C pango_builddir
 meson install -C pango_builddir
 echo "::endgroup::"

--- a/packing/build_pango_mac.sh
+++ b/packing/build_pango_mac.sh
@@ -87,41 +87,42 @@ cd pcre
       --enable-pcre32 \
       --enable-unicode-properties \
       --enable-pcregrep-libz \
-      --enable-pcregrep-libbz2
+      --enable-pcregrep-libbz2 \
+      --enable-static
 make
 make install
 cd ..
 echo "::endgroup::"
 
 echo "::group::Building and Install proxy-libintl"
-meson setup --buildtype=release libintlbuilddir proxy-libintl
+meson setup --buildtype=release --default-library=static libintlbuilddir proxy-libintl
 meson compile -C libintlbuilddir
 meson install -C libintlbuilddir
 echo "::endgroup::"
 
 echo "::group::Building and Install Zlib"
 cd zlib
-./configure --prefix=$PREFIX
+./configure --prefix=$PREFIX --enable-static
 make
 make install
 cd ..
 echo "::endgroup::"
 
 echo "::group::Building and Install Glib"
-meson setup --prefix=$PREFIX --buildtype=release -Dselinux=disabled -Dlibmount=enabled glib_builddir glib
+meson setup --prefix=$PREFIX --default-library=static --buildtype=release -Dselinux=disabled -Dlibmount=enabled glib_builddir glib
 meson compile -C glib_builddir
 meson install -C glib_builddir
 echo "::endgroup::"
 
 echo "::group::Building and Install Fribidi"
-meson setup --prefix=$PREFIX --buildtype=release fribidi_builddir fribidi
+meson setup --prefix=$PREFIX --default-library=static --buildtype=release fribidi_builddir fribidi
 meson compile -C fribidi_builddir
 meson install -C fribidi_builddir
 echo "::endgroup::"
 
 echo "::group::Building and Installing Gperf"
 cd gperf
-./configure --prefix=$PREFIX
+./configure --prefix=$PREFIX --enable-static
 make
 make install
 cd ..
@@ -129,7 +130,7 @@ echo "::endgroup::"
 
 echo "::group::Building and Installing Expat"
 cd expat
-./configure --prefix=$PREFIX
+./configure --prefix=$PREFIX --enable-static
 make
 make install
 cd ..
@@ -137,7 +138,7 @@ echo "::endgroup::"
 
 echo "::group::Building and Install Libpng"
 cd libpng
-./configure --prefix=$PREFIX
+./configure --prefix=$PREFIX --enable-static
 make
 make install
 cd ..
@@ -145,7 +146,7 @@ echo "::endgroup::"
 
 echo "::group::Building and Installing Freetype"
 cd freetype
-./configure --without-harfbuzz --prefix=$PREFIX
+./configure --without-harfbuzz --prefix=$PREFIX --enable-static
 make
 make install
 cd ..
@@ -153,7 +154,7 @@ echo "::endgroup::"
 
 echo "::group::Building and Install Fontconfig"
 rm -rf /usr/local/share/fontconfig/conf.avail
-meson setup --buildtype=release --prefix=$PREFIX --sysconfdir=$HOME -Ddoc=disabled -Dtests=disabled -Dtools=disabled fontconfig_builddir fontconfig
+meson setup --buildtype=release --default-library=static --prefix=$PREFIX --sysconfdir=$HOME -Ddoc=disabled -Dtests=disabled -Dtools=disabled fontconfig_builddir fontconfig
 meson compile -C fontconfig_builddir
 meson install -C fontconfig_builddir
 echo "::endgroup::"
@@ -161,7 +162,7 @@ echo "::endgroup::"
 
 echo "::group::Building and Installing Pixman"
 cd pixman
-./configure --prefix=$PREFIX
+./configure --prefix=$PREFIX --enable-static
 make
 make install
 cd ..
@@ -169,7 +170,7 @@ echo "::endgroup::"
 
 echo "::group::Building and Installing Cairo"
 cd cairo
-./configure --prefix=$PREFIX --enable-fontconfig --enable-freetype
+./configure --prefix=$PREFIX --enable-static --enable-fontconfig --enable-freetype
 make
 make install
 cd ..
@@ -181,13 +182,13 @@ cd ..
 echo "::endgroup::"
 
 echo "::group::Building and Installing Harfbuzz"
-meson setup --prefix=$PREFIX --buildtype=release -Dtests=disabled -Ddocs=disabled -Dgobject=disabled -Dcoretext=enabled -Dfreetype=enabled -Dglib=enabled harfbuzz_builddir harfbuzz
+meson setup --prefix=$PREFIX --default-library=static --buildtype=release -Dtests=disabled -Ddocs=disabled -Dgobject=disabled -Dcoretext=enabled -Dfreetype=enabled -Dglib=enabled harfbuzz_builddir harfbuzz
 meson compile -C harfbuzz_builddir
 meson install -C harfbuzz_builddir
 echo "::endgroup::"
 
 echo "::group::Buildling and Installing Pango"
-meson setup --prefix=$PREFIX --buildtype=release -Dintrospection=disabled pango_builddir pango
+meson setup --prefix=$PREFIX --default-library=static --buildtype=release -Dintrospection=disabled pango_builddir pango
 meson compile -C pango_builddir
 meson install -C pango_builddir
 echo "::endgroup::"

--- a/packing/build_pango_mac.sh
+++ b/packing/build_pango_mac.sh
@@ -131,11 +131,16 @@ cd ..
 echo "::endgroup::"
 
 echo "::group::Building and Installing Cairo"
-cd cairo
-./configure --prefix=$PREFIX --enable-fontconfig --enable-freetype
-make
-make install
-cd ..
+#cd cairo
+#./configure --prefix=$PREFIX --enable-fontconfig --enable-freetype
+#make
+#make install
+#cd ..
+
+#try using meson to see if things are fixed.
+meson setup --prefix=$PREFIX --buildtype=release -Dfontconfig=enabled -Dfreetype=enabled -Dtests=disabled cairo_builddir cairo
+meson compile -C cairo_builddir
+meson install -C cairo_builddir
 echo "::endgroup::"
 
 echo "::group::Building and Installing Harfbuzz"

--- a/packing/build_pango_mac.sh
+++ b/packing/build_pango_mac.sh
@@ -41,7 +41,9 @@ python $FILE_PATH/packing/download_and_extract.py "https://mirrors.kernel.org/gn
 python $FILE_PATH/packing/download_and_extract.py "https://downloads.sourceforge.net/project/libpng/libpng16/${LIBPNG_VERSION}/libpng-${LIBPNG_VERSION}.tar.xz" libpng
 python $FILE_PATH/packing/download_and_extract.py "https://github.com/harfbuzz/harfbuzz/releases/download/${HARFBUZZ_VERSION}/harfbuzz-${HARFBUZZ_VERSION}.tar.xz" harfbuzz
 python $FILE_PATH/packing/download_and_extract.py "https://zlib.net/fossils/zlib-${ZLIB_VERSION}.tar.gz" zlib
-python $FILE_PATH/packing/download_and_extract.py "https://github.com/frida/proxy-libintl/archive/0.1.tar.gz" proxy-libintl
+curl -L "https://github.com/frida/proxy-libintl/archive/0.1.tar.gz" -o 0.1.tar.gz
+tar -xf 0.1.tar.gz
+mv proxy-libintl-0.1 proxy-libintl
 python -m pip uninstall -y requests
 
 echo "::endgroup::"

--- a/packing/build_pango_mac.sh
+++ b/packing/build_pango_mac.sh
@@ -52,13 +52,13 @@ echo "Installing Meson and Ninja"
 pip3 install -U meson ninja
 echo "::endgroup::"
 
-export PKG_CONFIG_PATH=/home/pango/lib/pkgconfig
-export LD_LIBRARY_PATH=/home/pango/lib
+export PKG_CONFIG_PATH=$HOME/pango/lib/pkgconfig
+export LD_LIBRARY_PATH=$HOME/pango/lib
 
 echo "::group::Building and Install IntlTool"
 cd intltool
-cpan App::cpanminus
-cpan XML::Parser
+cpan App::cpanminus >> cpan.txt
+cpan XML::Parser >> cpan.txt
 ./configure --disable-silent-rules --prefix=/home/pango
 make
 make install

--- a/packing/build_pango_mac.sh
+++ b/packing/build_pango_mac.sh
@@ -48,7 +48,7 @@ mv proxy-libintl-0.1 proxy-libintl
 python -m pip uninstall -y requests
 
 echo "::endgroup::"
-
+rm -rf /usr/local
 export PKG_CONFIG_PATH=$PREFIX/lib/pkgconfig
 LIB_INSTALL_PREFIX=$PREFIX
 echo "::group::Install Meson"

--- a/packing/build_pango_mac.sh
+++ b/packing/build_pango_mac.sh
@@ -14,6 +14,7 @@ GPERF_VERSION=3.1
 LIBPNG_VERSION=1.6.37
 HARFBUZZ_VERSION=2.7.3
 ZLIB_VERSION=1.2.11
+INTLTOOL_VERSION=0.51.0
 
 FILE_PATH=$PWD
 
@@ -40,6 +41,7 @@ python $FILE_PATH/packing/download_and_extract.py "https://mirrors.kernel.org/gn
 python $FILE_PATH/packing/download_and_extract.py "https://downloads.sourceforge.net/project/libpng/libpng16/${LIBPNG_VERSION}/libpng-${LIBPNG_VERSION}.tar.xz" libpng
 python $FILE_PATH/packing/download_and_extract.py "https://github.com/harfbuzz/harfbuzz/releases/download/${HARFBUZZ_VERSION}/harfbuzz-${HARFBUZZ_VERSION}.tar.xz" harfbuzz
 python $FILE_PATH/packing/download_and_extract.py "https://zlib.net/fossils/zlib-${ZLIB_VERSION}.tar.gz" zlib
+python $FILE_PATH/packing/download_and_extract.py "https://launchpad.net/intltool/trunk/${INTLTOOL_VERSION}/+download/intltool-${INTLTOOL_VERSION}.tar.gz" intltool
 python -m pip uninstall -y requests
 
 echo "::endgroup::"
@@ -53,6 +55,14 @@ echo "::endgroup::"
 echo "::group::Building and Install Zlib"
 cd zlib
 ./configure
+make
+make install
+cd ..
+echo "::endgroup::"
+
+echo "::group::Building and Install IntlTool"
+cd intltool
+./configure --disable-silent-rules
 make
 make install
 cd ..

--- a/packing/build_pango_mac.sh
+++ b/packing/build_pango_mac.sh
@@ -56,6 +56,7 @@ python -m pip uninstall -y requests
 echo "::endgroup::"
 
 export PKG_CONFIG_PATH=$PREFIX/lib/pkgconfig
+export CMAKE_PREFIX_PATH=$PKG_CONFIG_PATH
 LIB_INSTALL_PREFIX=$PREFIX
 echo "::group::Install Meson"
 echo "Installing Meson and Ninja"
@@ -68,13 +69,13 @@ brew uninstall --ignore-dependencies pcre
 brew uninstall --ignore-dependencies libpng
 echo "::endgroup::"
 
-# echo "::group::Building and Install Brotoli"
-# cd brotli
-# cmake . -DCMAKE_INSTALL_PREFIX=${PREFIX}
-# make
-# make install
-# cd ..
-# echo "::endgroup::"
+echo "::group::Building and Install Brotoli"
+cd brotli
+cmake . -DCMAKE_INSTALL_PREFIX=${PREFIX}
+make
+make install
+cd ..
+echo "::endgroup::"
 
 echo "::group::Building and Install PCRE"
 cd pcre

--- a/packing/build_pango_mac.sh
+++ b/packing/build_pango_mac.sh
@@ -86,7 +86,7 @@ cd pcre
       --enable-pcre32 \
       --enable-unicode-properties \
       --enable-pcregrep-libz \
-      --enable-pcregrep-libbz2 \
+      --enable-pcregrep-libbz2
 make
 make install
 cd ..

--- a/packing/build_pango_mac.sh
+++ b/packing/build_pango_mac.sh
@@ -48,7 +48,7 @@ mv proxy-libintl-0.1 proxy-libintl
 python -m pip uninstall -y requests
 
 echo "::endgroup::"
-rm -rf /usr/local
+
 export PKG_CONFIG_PATH=$PREFIX/lib/pkgconfig
 LIB_INSTALL_PREFIX=$PREFIX
 echo "::group::Install Meson"

--- a/packing/build_pango_mac.sh
+++ b/packing/build_pango_mac.sh
@@ -50,7 +50,7 @@ python -m pip uninstall -y requests
 echo "::endgroup::"
 
 export PKG_CONFIG_PATH=$PREFIX/lib/pkgconfig
-
+LIB_INSTALL_PREFIX=$PREFIX
 echo "::group::Install Meson"
 echo "Installing Meson and Ninja"
 pip3 install -U meson ninja

--- a/packing/build_pango_mac.sh
+++ b/packing/build_pango_mac.sh
@@ -77,6 +77,7 @@ cd ..
 echo "::endgroup::"
 
 echo "::group::Building and Install PCRE"
+cd pcre
 ./configure \
       --prefix=$PREFIX \
       --enable-utf8 \
@@ -88,6 +89,7 @@ echo "::group::Building and Install PCRE"
       --enable-pcregrep-libbz2 \
 make
 make install
+cd ..
 echo "::endgroup::"
 
 echo "::group::Building and Install proxy-libintl"

--- a/packing/build_pango_mac.sh
+++ b/packing/build_pango_mac.sh
@@ -59,7 +59,7 @@ echo "::group::Building and Install IntlTool"
 cd intltool
 cpan App::cpanminus >> cpan.txt
 cpan XML::Parser >> cpan.txt
-./configure --disable-silent-rules --prefix=/home/pango
+./configure --disable-silent-rules --prefix=$HOME/pango
 make
 make install
 cd ..
@@ -67,27 +67,27 @@ echo "::endgroup::"
 
 echo "::group::Building and Install Zlib"
 cd zlib
-./configure --prefix=/home/pango
+./configure --prefix=$HOME/pango
 make
 make install
 cd ..
 echo "::endgroup::"
 
 echo "::group::Building and Install Glib"
-meson setup --prefix=/home/pango --buildtype=release -Dselinux=disabled -Dlibmount=enabled glib_builddir glib
+meson setup --prefix=$HOME/pango --buildtype=release -Dselinux=disabled -Dlibmount=enabled glib_builddir glib
 meson compile -C glib_builddir
 meson install -C glib_builddir
 echo "::endgroup::"
 
 echo "::group::Building and Install Fribidi"
-meson setup --prefix=/home/pango --buildtype=release fribidi_builddir fribidi
+meson setup --prefix=$HOME/pango --buildtype=release fribidi_builddir fribidi
 meson compile -C fribidi_builddir
 meson install -C fribidi_builddir
 echo "::endgroup::"
 
 echo "::group::Building and Installing Gperf"
 cd gperf
-./configure --prefix=/home/pango
+./configure --prefix=$HOME/pango
 make
 make install
 cd ..
@@ -95,7 +95,7 @@ echo "::endgroup::"
 
 echo "::group::Building and Installing Expat"
 cd expat
-./configure --prefix=/home/pango
+./configure --prefix=$HOME/pango
 make
 make install
 cd ..
@@ -103,14 +103,14 @@ echo "::endgroup::"
 
 echo "::group::Building and Installing Freetype"
 cd freetype
-./configure --without-harfbuzz --prefix=/home/pango
+./configure --without-harfbuzz --prefix=$HOME/pango
 make
 make install
 cd ..
 echo "::endgroup::"
 
 echo "::group::Building and Install Fontconfig"
-meson setup --prefix=/home/pango --buildtype=release -Ddoc=disabled -Dtests=disabled -Dtools=disabled fontconfig_builddir fontconfig
+meson setup --prefix=$HOME/pango --buildtype=release -Ddoc=disabled -Dtests=disabled -Dtools=disabled fontconfig_builddir fontconfig
 meson compile -C fontconfig_builddir
 meson install -C fontconfig_builddir
 echo "::endgroup::"
@@ -125,7 +125,7 @@ echo "::endgroup::"
 
 echo "::group::Building and Installing Pixman"
 cd pixman
-./configure --prefix=/home/pango
+./configure --prefix=$HOME/pango
 make
 make install
 cd ..
@@ -133,20 +133,20 @@ echo "::endgroup::"
 
 echo "::group::Building and Installing Cairo"
 cd cairo
-./configure --enable-fontconfig --enable-freetype --prefix=/home/pango
+./configure --enable-fontconfig --enable-freetype --prefix=$HOME/pango
 make
 make install
 cd ..
 echo "::endgroup::"
 
 echo "::group::Building and Installing Harfbuzz"
-meson setup --prefix=/home/pango --buildtype=release -Dtests=disabled -Ddocs=disabled harfbuzz_builddir harfbuzz
+meson setup --prefix=$HOME/pango --buildtype=release -Dtests=disabled -Ddocs=disabled harfbuzz_builddir harfbuzz
 meson compile -C harfbuzz_builddir
 meson install -C harfbuzz_builddir
 echo "::endgroup::"
 
 echo "::group::Buildling and Installing Pango"
-meson setup --prefix=/home/pango --buildtype=release -Dintrospection=false pango_builddir pango
+meson setup --prefix=$HOME/pango --buildtype=release -Dintrospection=false pango_builddir pango
 meson compile -C pango_builddir
 meson install -C pango_builddir
 echo "::endgroup::"

--- a/packing/build_pango_mac.sh
+++ b/packing/build_pango_mac.sh
@@ -16,6 +16,7 @@ HARFBUZZ_VERSION=2.7.3
 ZLIB_VERSION=1.2.11
 INTLTOOL_VERSION=0.51.0
 BROTLI_VERSION=1.0.9
+PCRE_VERSION=8.44
 
 FILE_PATH=$PWD
 PREFIX=$HOME/pangobuild
@@ -44,6 +45,7 @@ python $FILE_PATH/packing/download_and_extract.py "https://downloads.sourceforge
 python $FILE_PATH/packing/download_and_extract.py "https://github.com/harfbuzz/harfbuzz/releases/download/${HARFBUZZ_VERSION}/harfbuzz-${HARFBUZZ_VERSION}.tar.xz" harfbuzz
 python $FILE_PATH/packing/download_and_extract.py "https://zlib.net/fossils/zlib-${ZLIB_VERSION}.tar.gz" zlib
 python $FILE_PATH/packing/download_and_extract.py "https://github.com/google/brotli/archive/v${BROTLI_VERSION}.tar.gz" brotli
+python $FILE_PATH/packing/download_and_extract.py "https://ftp.pcre.org/pub/pcre/pcre-${PCRE_VERSION}.tar.bz2" pcre
 curl -L "https://github.com/frida/proxy-libintl/archive/0.1.tar.gz" -o 0.1.tar.gz
 tar -xf 0.1.tar.gz
 mv proxy-libintl-0.1 proxy-libintl
@@ -70,6 +72,20 @@ cmake . -DCMAKE_INSTALL_PREFIX=${PREFIX}
 make
 make install
 cd ..
+echo "::endgroup::"
+
+echo "::group::Building and Install PCRE"
+./configure \
+      --prefix=$PREFIX \
+      --enable-utf8 \
+      --enable-pcre8  \
+      --enable-pcre16 \
+      --enable-pcre32 \
+      --enable-unicode-properties \
+      --enable-pcregrep-libz \
+      --enable-pcregrep-libbz2 \
+make
+make install
 echo "::endgroup::"
 
 echo "::group::Building and Install proxy-libintl"

--- a/packing/build_pango_mac.sh
+++ b/packing/build_pango_mac.sh
@@ -68,13 +68,13 @@ brew uninstall --ignore-dependencies pcre
 brew uninstall --ignore-dependencies libpng
 echo "::endgroup::"
 
-echo "::group::Building and Install Brotoli"
-cd brotli
-cmake . -DCMAKE_INSTALL_PREFIX=${PREFIX}
-make
-make install
-cd ..
-echo "::endgroup::"
+# echo "::group::Building and Install Brotoli"
+# cd brotli
+# cmake . -DCMAKE_INSTALL_PREFIX=${PREFIX}
+# make
+# make install
+# cd ..
+# echo "::endgroup::"
 
 echo "::group::Building and Install PCRE"
 cd pcre

--- a/packing/build_pango_mac.sh
+++ b/packing/build_pango_mac.sh
@@ -52,14 +52,12 @@ echo "Installing Meson and Ninja"
 pip3 install -U meson ninja
 echo "::endgroup::"
 
-export PKG_CONFIG_PATH=$HOME/pango/lib/pkgconfig
-export LD_LIBRARY_PATH=$HOME/pango/lib
 
 echo "::group::Building and Install IntlTool"
 cd intltool
 cpan App::cpanminus >> cpan.txt
 cpan XML::Parser >> cpan.txt
-./configure --disable-silent-rules --prefix=$HOME/pango
+./configure --disable-silent-rules
 make
 make install
 cd ..
@@ -67,27 +65,27 @@ echo "::endgroup::"
 
 echo "::group::Building and Install Zlib"
 cd zlib
-./configure --prefix=$HOME/pango
+./configure
 make
 make install
 cd ..
 echo "::endgroup::"
 
 echo "::group::Building and Install Glib"
-meson setup --prefix=$HOME/pango --buildtype=release -Dselinux=disabled -Dlibmount=enabled glib_builddir glib
+meson setup --buildtype=release -Dselinux=disabled -Dlibmount=enabled glib_builddir glib
 meson compile -C glib_builddir
 meson install -C glib_builddir
 echo "::endgroup::"
 
 echo "::group::Building and Install Fribidi"
-meson setup --prefix=$HOME/pango --buildtype=release fribidi_builddir fribidi
+meson setup --buildtype=release fribidi_builddir fribidi
 meson compile -C fribidi_builddir
 meson install -C fribidi_builddir
 echo "::endgroup::"
 
 echo "::group::Building and Installing Gperf"
 cd gperf
-./configure --prefix=$HOME/pango
+./configure
 make
 make install
 cd ..
@@ -95,7 +93,7 @@ echo "::endgroup::"
 
 echo "::group::Building and Installing Expat"
 cd expat
-./configure --prefix=$HOME/pango
+./configure
 make
 make install
 cd ..
@@ -103,14 +101,14 @@ echo "::endgroup::"
 
 echo "::group::Building and Installing Freetype"
 cd freetype
-./configure --without-harfbuzz --prefix=$HOME/pango
+./configure --without-harfbuzz
 make
 make install
 cd ..
 echo "::endgroup::"
 
 echo "::group::Building and Install Fontconfig"
-meson setup --prefix=$HOME/pango --buildtype=release -Ddoc=disabled -Dtests=disabled -Dtools=disabled fontconfig_builddir fontconfig
+meson setup --buildtype=release -Ddoc=disabled -Dtests=disabled -Dtools=disabled fontconfig_builddir fontconfig
 meson compile -C fontconfig_builddir
 meson install -C fontconfig_builddir
 echo "::endgroup::"
@@ -125,7 +123,7 @@ echo "::endgroup::"
 
 echo "::group::Building and Installing Pixman"
 cd pixman
-./configure --prefix=$HOME/pango
+./configure
 make
 make install
 cd ..
@@ -133,20 +131,20 @@ echo "::endgroup::"
 
 echo "::group::Building and Installing Cairo"
 cd cairo
-./configure --enable-fontconfig --enable-freetype --prefix=$HOME/pango
+./configure --enable-fontconfig --enable-freetype
 make
 make install
 cd ..
 echo "::endgroup::"
 
 echo "::group::Building and Installing Harfbuzz"
-meson setup --prefix=$HOME/pango --buildtype=release -Dtests=disabled -Ddocs=disabled harfbuzz_builddir harfbuzz
+meson setup --buildtype=release -Dtests=disabled -Ddocs=disabled -Dgobject=disabled harfbuzz_builddir harfbuzz
 meson compile -C harfbuzz_builddir
 meson install -C harfbuzz_builddir
 echo "::endgroup::"
 
 echo "::group::Buildling and Installing Pango"
-meson setup --prefix=$HOME/pango --buildtype=release -Dintrospection=false pango_builddir pango
+meson setup --buildtype=release -Dintrospection=disabled pango_builddir pango
 meson compile -C pango_builddir
 meson install -C pango_builddir
 echo "::endgroup::"

--- a/packing/build_pango_mac.sh
+++ b/packing/build_pango_mac.sh
@@ -48,9 +48,6 @@ python $FILE_PATH/packing/download_and_extract.py "https://ftp.pcre.org/pub/pcre
 curl -L "https://github.com/frida/proxy-libintl/archive/0.1.tar.gz" -o 0.1.tar.gz
 tar -xf 0.1.tar.gz
 mv proxy-libintl-0.1 proxy-libintl
-curl -L "https://github.com/google/brotli/archive/v${BROTLI_VERSION}.tar.gz" -o brotli${BROTLI_VERSION}.tar.gz
-tar -xf brotli${BROTLI_VERSION}.tar.gz
-mv brotli-${BROTLI_VERSION} brotli
 python -m pip uninstall -y requests
 
 echo "::endgroup::"
@@ -67,14 +64,6 @@ echo "::group::Removing the things from brew"
 brew uninstall --ignore-dependencies brotli
 brew uninstall --ignore-dependencies pcre
 brew uninstall --ignore-dependencies libpng
-echo "::endgroup::"
-
-echo "::group::Building and Install Brotoli"
-cd brotli
-cmake . -DCMAKE_INSTALL_PREFIX=${PREFIX}
-make
-make install
-cd ..
 echo "::endgroup::"
 
 echo "::group::Building and Install PCRE"

--- a/packing/build_pango_mac.sh
+++ b/packing/build_pango_mac.sh
@@ -139,7 +139,7 @@ cd ..
 echo "::endgroup::"
 
 echo "::group::Building and Installing Harfbuzz"
-meson setup --buildtype=release -Dtests=disabled -Ddocs=disabled -Dgobject=disabled harfbuzz_builddir harfbuzz
+meson setup --buildtype=release -Dtests=disabled -Ddocs=disabled -Dgobject=disabled -Dcoretext=enabled -Dfreetype=enabled -Dglib=enabled harfbuzz_builddir harfbuzz
 meson compile -C harfbuzz_builddir
 meson install -C harfbuzz_builddir
 echo "::endgroup::"

--- a/packing/build_pango_mac.sh
+++ b/packing/build_pango_mac.sh
@@ -47,8 +47,8 @@ mv proxy-libintl-0.1 proxy-libintl
 python -m pip uninstall -y requests
 
 echo "::endgroup::"
-
-export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig
+PREFIX=$HOME/pangobuild
+export PKG_CONFIG_PATH=$PREFIX/lib/pkgconfig
 
 echo "::group::Install Meson"
 echo "Installing Meson and Ninja"
@@ -64,27 +64,27 @@ echo "::endgroup::"
 
 echo "::group::Building and Install Zlib"
 cd zlib
-./configure
+./configure --prefix=$PREFIX
 make
 make install
 cd ..
 echo "::endgroup::"
 
 echo "::group::Building and Install Glib"
-meson setup --buildtype=release -Dselinux=disabled -Dlibmount=enabled glib_builddir glib
+meson setup --prefix=$PREFIX --buildtype=release -Dselinux=disabled -Dlibmount=enabled glib_builddir glib
 meson compile -C glib_builddir
 meson install -C glib_builddir
 echo "::endgroup::"
 
 echo "::group::Building and Install Fribidi"
-meson setup --buildtype=release fribidi_builddir fribidi
+meson setup --prefix=$PREFIX --buildtype=release fribidi_builddir fribidi
 meson compile -C fribidi_builddir
 meson install -C fribidi_builddir
 echo "::endgroup::"
 
 echo "::group::Building and Installing Gperf"
 cd gperf
-./configure
+./configure --prefix=$PREFIX
 make
 make install
 cd ..
@@ -92,7 +92,7 @@ echo "::endgroup::"
 
 echo "::group::Building and Installing Expat"
 cd expat
-./configure
+./configure --prefix=$PREFIX
 make
 make install
 cd ..
@@ -100,7 +100,7 @@ echo "::endgroup::"
 
 echo "::group::Building and Installing Freetype"
 cd freetype
-./configure --without-harfbuzz
+./configure --without-harfbuzz --prefix=$PREFIX
 make
 make install
 cd ..
@@ -108,14 +108,14 @@ echo "::endgroup::"
 
 echo "::group::Building and Install Fontconfig"
 rm -rf /usr/local/share/fontconfig/conf.avail
-meson setup --buildtype=release --sysconfdir=$HOME -Ddoc=disabled -Dtests=disabled -Dtools=disabled fontconfig_builddir fontconfig
+meson setup --buildtype=release --prefix=$PREFIX --sysconfdir=$HOME -Ddoc=disabled -Dtests=disabled -Dtools=disabled fontconfig_builddir fontconfig
 meson compile -C fontconfig_builddir
 meson install -C fontconfig_builddir
 echo "::endgroup::"
 
 echo "::group::Building and Install Libpng"
 cd libpng
-./configure
+./configure --prefix=$PREFIX
 make
 make install
 cd ..
@@ -123,7 +123,7 @@ echo "::endgroup::"
 
 echo "::group::Building and Installing Pixman"
 cd pixman
-./configure
+./configure --prefix=$PREFIX
 make
 make install
 cd ..
@@ -131,20 +131,20 @@ echo "::endgroup::"
 
 echo "::group::Building and Installing Cairo"
 cd cairo
-./configure --enable-fontconfig --enable-freetype
+./configure --prefix=$PREFIX --enable-fontconfig --enable-freetype
 make
 make install
 cd ..
 echo "::endgroup::"
 
 echo "::group::Building and Installing Harfbuzz"
-meson setup --buildtype=release -Dtests=disabled -Ddocs=disabled -Dgobject=disabled -Dcoretext=enabled -Dfreetype=enabled -Dglib=enabled harfbuzz_builddir harfbuzz
+meson setup --prefix=$PREFIX --buildtype=release -Dtests=disabled -Ddocs=disabled -Dgobject=disabled -Dcoretext=enabled -Dfreetype=enabled -Dglib=enabled harfbuzz_builddir harfbuzz
 meson compile -C harfbuzz_builddir
 meson install -C harfbuzz_builddir
 echo "::endgroup::"
 
 echo "::group::Buildling and Installing Pango"
-meson setup --buildtype=release -Dintrospection=disabled pango_builddir pango
+meson setup --prefix=$PREFIX --buildtype=release -Dintrospection=disabled pango_builddir pango
 meson compile -C pango_builddir
 meson install -C pango_builddir
 echo "::endgroup::"

--- a/packing/build_pango_mac.sh
+++ b/packing/build_pango_mac.sh
@@ -109,7 +109,7 @@ echo "::endgroup::"
 
 echo "::group::Building and Install Fontconfig"
 rm -rf /usr/local/share/fontconfig/conf.avail
-meson setup --buildtype=release -Ddoc=disabled -Dtests=disabled -Dtools=disabled fontconfig_builddir fontconfig
+meson setup --buildtype=release --sysconfdir=$HOME -Ddoc=disabled -Dtests=disabled -Dtools=disabled fontconfig_builddir fontconfig
 meson compile -C fontconfig_builddir
 meson install -C fontconfig_builddir
 echo "::endgroup::"

--- a/packing/build_pango_mac.sh
+++ b/packing/build_pango_mac.sh
@@ -41,7 +41,7 @@ python $FILE_PATH/packing/download_and_extract.py "https://mirrors.kernel.org/gn
 python $FILE_PATH/packing/download_and_extract.py "https://downloads.sourceforge.net/project/libpng/libpng16/${LIBPNG_VERSION}/libpng-${LIBPNG_VERSION}.tar.xz" libpng
 python $FILE_PATH/packing/download_and_extract.py "https://github.com/harfbuzz/harfbuzz/releases/download/${HARFBUZZ_VERSION}/harfbuzz-${HARFBUZZ_VERSION}.tar.xz" harfbuzz
 python $FILE_PATH/packing/download_and_extract.py "https://zlib.net/fossils/zlib-${ZLIB_VERSION}.tar.gz" zlib
-python $FILE_PATH/packing/download_and_extract.py "https://launchpad.net/intltool/trunk/${INTLTOOL_VERSION}/+download/intltool-${INTLTOOL_VERSION}.tar.gz" intltool
+python $FILE_PATH/packing/download_and_extract.py "https://github.com/frida/proxy-libintl/archive/0.1.tar.gz" proxy-libintl
 python -m pip uninstall -y requests
 
 echo "::endgroup::"
@@ -53,14 +53,10 @@ pip3 install -U meson ninja
 echo "::endgroup::"
 
 
-echo "::group::Building and Install IntlTool"
-cd intltool
-cpan App::cpanminus >> cpan.txt
-cpan XML::Parser >> cpan.txt
-./configure --disable-silent-rules
-make
-make install
-cd ..
+echo "::group::Building and Install proxy-libintl"
+meson setup --buildtype=release libintlbuilddir proxy-libintl
+meson compile -C libintlbuilddir
+meson install -C libintlbuilddir
 echo "::endgroup::"
 
 echo "::group::Building and Install Zlib"

--- a/packing/build_pango_mac.sh
+++ b/packing/build_pango_mac.sh
@@ -18,7 +18,7 @@ INTLTOOL_VERSION=0.51.0
 
 FILE_PATH=$PWD
 
-cd $TMP
+cd $TEMP
 if [ -d "$PWD/pango" ] ; then
   echo "Skipping Build"
   exit 0

--- a/packing/build_pango_mac.sh
+++ b/packing/build_pango_mac.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!#!/bin/bash
 # build and install pango
 set -e
 

--- a/packing/build_pango_mac.sh
+++ b/packing/build_pango_mac.sh
@@ -131,16 +131,16 @@ cd ..
 echo "::endgroup::"
 
 echo "::group::Building and Installing Cairo"
-#cd cairo
-#./configure --prefix=$PREFIX --enable-fontconfig --enable-freetype
-#make
-#make install
-#cd ..
+cd cairo
+./configure --prefix=$PREFIX --enable-fontconfig --enable-freetype
+make
+make install
+cd ..
 
 #try using meson to see if things are fixed.
-meson setup --prefix=$PREFIX --buildtype=release -Dfontconfig=enabled -Dfreetype=enabled -Dtests=disabled cairo_builddir cairo
-meson compile -C cairo_builddir
-meson install -C cairo_builddir
+# meson setup --prefix=$PREFIX --buildtype=release -Dfontconfig=enabled -Dfreetype=enabled -Dtests=disabled cairo_builddir cairo
+# meson compile -C cairo_builddir
+# meson install -C cairo_builddir
 echo "::endgroup::"
 
 echo "::group::Building and Installing Harfbuzz"

--- a/packing/build_pango_mac.sh
+++ b/packing/build_pango_mac.sh
@@ -15,6 +15,7 @@ LIBPNG_VERSION=1.6.37
 HARFBUZZ_VERSION=2.7.3
 ZLIB_VERSION=1.2.11
 INTLTOOL_VERSION=0.51.0
+BROTLI_VERSION=1.0.9
 
 FILE_PATH=$PWD
 PREFIX=$HOME/pangobuild
@@ -42,6 +43,7 @@ python $FILE_PATH/packing/download_and_extract.py "https://mirrors.kernel.org/gn
 python $FILE_PATH/packing/download_and_extract.py "https://downloads.sourceforge.net/project/libpng/libpng16/${LIBPNG_VERSION}/libpng-${LIBPNG_VERSION}.tar.xz" libpng
 python $FILE_PATH/packing/download_and_extract.py "https://github.com/harfbuzz/harfbuzz/releases/download/${HARFBUZZ_VERSION}/harfbuzz-${HARFBUZZ_VERSION}.tar.xz" harfbuzz
 python $FILE_PATH/packing/download_and_extract.py "https://zlib.net/fossils/zlib-${ZLIB_VERSION}.tar.gz" zlib
+python $FILE_PATH/packing/download_and_extract.py "https://github.com/google/brotli/archive/v${BROTLI_VERSION}.tar.gz" brotli
 curl -L "https://github.com/frida/proxy-libintl/archive/0.1.tar.gz" -o 0.1.tar.gz
 tar -xf 0.1.tar.gz
 mv proxy-libintl-0.1 proxy-libintl
@@ -60,6 +62,14 @@ echo "::group::Removing the things from brew"
 brew uninstall --ignore-dependencies brotli
 brew uninstall --ignore-dependencies pcre
 brew uninstall --ignore-dependencies libpng
+echo "::endgroup::"
+
+echo "::group::Building and Install Brotoli"
+cd brotli
+cmake . -DCMAKE_INSTALL_PREFIX=${PREFIX}
+make
+make install
+cd ..
 echo "::endgroup::"
 
 echo "::group::Building and Install proxy-libintl"

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ def get_library_config(name):
     """
     try:
         proc = Popen(
-            ["pkg-config", "--cflags", "--libs", "--static", name],
+            ["pkg-config", "--cflags", "--libs", name],
             stdout=PIPE,
             stderr=PIPE,
         )

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ def get_library_config(name):
     """
     try:
         proc = Popen(
-            ["pkg-config", "--cflags", "--libs","--static", name],
+            ["pkg-config", "--cflags", "--libs", "--static", name],
             stdout=PIPE,
             stderr=PIPE,
         )

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ def get_library_config(name):
     """
     try:
         proc = Popen(
-            ["pkg-config", "--cflags", "--libs", name],
+            ["pkg-config", "--cflags", "--libs","--static", name],
             stdout=PIPE,
             stderr=PIPE,
         )


### PR DESCRIPTION
Build Pango on macOS machines rather than using from Brew. This fixes #19 

I would welcome @ManimCommunity/macos to test these wheels build previously at https://github.com/ManimCommunity/ManimPango/suites/1967413638/artifacts/39061127

I will not be waiting for any review as it is just CI configuration.