### PR TITLE
Fix unicode font filenames

### DIFF
--- a/manimpango/cmanimpango.pxd
+++ b/manimpango/cmanimpango.pxd
@@ -169,16 +169,17 @@ IF UNAME_SYSNAME == "Linux":
         void FcConfigAppFontClear(void*)
 ELIF UNAME_SYSNAME == "Windows":
     cdef extern from "windows.h":
-        ctypedef const char* LPCSTR
+        ctypedef Py_UNICODE WCHAR
+        ctypedef const WCHAR* LPCWSTR
         ctypedef enum DWORD:
             FR_PRIVATE
-        int AddFontResourceExA(
-            LPCSTR name,
+        int AddFontResourceExW(
+            LPCWSTR name,
             DWORD fl,
             unsigned int res
         )
-        bint RemoveFontResourceExA(
-            LPCSTR name,
+        bint RemoveFontResourceExW(
+            LPCWSTR name,
             DWORD  fl,
             unsigned int pdv
         )

--- a/manimpango/cmanimpango.pyx
+++ b/manimpango/cmanimpango.pyx
@@ -473,7 +473,7 @@ IF UNAME_SYSNAME == "Windows":
                 False means there was an unknown error
         Examples
         --------
-        >>> register_font("/home/roboto.tff")
+        >>> register_font("C:/home/roboto.tff")
         1
         Raises
         ------
@@ -483,10 +483,8 @@ IF UNAME_SYSNAME == "Windows":
         a=Path(font_path)
         assert a.exists(), f"font doesn't exist at {a.absolute()}"
         font_path = str(a.absolute())
-        font_path_bytes=font_path.encode('ascii')
-        cdef LPCSTR fontPath = font_path_bytes
-        fontAddStatus = AddFontResourceExA(
-            font_path_bytes,
+        fontAddStatus = AddFontResourceExW(
+            <bytes>font_path,
             FR_PRIVATE,
             0
         )
@@ -515,10 +513,8 @@ IF UNAME_SYSNAME == "Windows":
         a=Path(font_path)
         assert a.exists(), f"font doesn't exist at {a.absolute()}"
         font_path = str(a.absolute())
-        font_path_bytes=font_path.encode('ascii')
-        cdef LPCSTR fontPath = font_path_bytes
-        return RemoveFontResourceExA(
-            font_path_bytes,
+        return RemoveFontResourceExW(
+            <bytes>font_path,
             FR_PRIVATE,
             0
         )

--- a/manimpango/cmanimpango.pyx
+++ b/manimpango/cmanimpango.pyx
@@ -428,7 +428,7 @@ IF UNAME_SYSNAME == "Linux":
         a=Path(font_path)
         assert a.exists(), f"font doesn't exist at {a.absolute()}"
         font_path = str(a.absolute())
-        font_path_bytes=font_path.encode('ascii')
+        font_path_bytes=font_path.encode('utf-8')
         cdef const unsigned char* fontPath = font_path_bytes
         fontAddStatus = FcConfigAppFontAddFile(FcConfigGetCurrent(), fontPath)
         if fontAddStatus:

--- a/tests/test_fonts.py
+++ b/tests/test_fonts.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import sys
 from pathlib import Path
+from shutil import copyfile
 
 import manim
 import pytest
@@ -18,6 +19,13 @@ font_lists = {
     ).absolute(): "Bungee Color Regular",
     (FONT_DIR / "NotoNastaliqUrdu-Regular.ttf").absolute(): "Noto Nastaliq Urdu",
 }
+
+
+def test_unicode_font_name(tmpdir):
+    final_font = str(Path(tmpdir, "庞门正.ttf").absolute())
+    copyfile(FONT_DIR / "AdobeVFPrototype.ttf", final_font)
+    assert manimpango.register_font(final_font)
+    assert manimpango.unregister_font(final_font)
 
 
 def test_register_font():


### PR DESCRIPTION
Fixes https://github.com/ManimCommunity/ManimPango/issues/21
Unicode version of function communicating to win32 API
are used instead of ascii version of the same functions.
Also added a test for the same.