### PR TITLE
Add unicode support to MarkupUtils.validate

### DIFF
--- a/manimpango/cmanimpango.pyx
+++ b/manimpango/cmanimpango.pyx
@@ -269,9 +269,8 @@ def text2svg(
 class MarkupUtils:
     @staticmethod
     def validate(text: str) -> bool:
-        length = len(text)
         text_bytes = text.encode("utf-8")
-        return pango_parse_markup(text_bytes, <int>length, 0, NULL, NULL, NULL, NULL)
+        return pango_parse_markup(text_bytes, -1, 0, NULL, NULL, NULL, NULL)
 
     @staticmethod
     def text2svg(

--- a/tests/test_markup.py
+++ b/tests/test_markup.py
@@ -8,6 +8,9 @@ def test_good_markup():
     assert manimpango.MarkupUtils.validate(
         "<b>bar</b>"
     ), '"<b>bar</b>" should not fail validation'
+    assert manimpango.MarkUtils.validate(
+        "வணக்கம்",
+    ), '"வணக்கம்" should not fails'
 
 
 def test_bad_markup():

--- a/tests/test_markup.py
+++ b/tests/test_markup.py
@@ -8,7 +8,7 @@ def test_good_markup():
     assert manimpango.MarkupUtils.validate(
         "<b>bar</b>"
     ), '"<b>bar</b>" should not fail validation'
-    assert manimpango.MarkUtils.validate(
+    assert manimpango.MarkupUtils.validate(
         "வணக்கம்",
     ), '"வணக்கம்" should not fails'
 

--- a/tests/test_markup.py
+++ b/tests/test_markup.py
@@ -10,7 +10,7 @@ def test_good_markup():
     ), '"<b>bar</b>" should not fail validation'
     assert manimpango.MarkupUtils.validate(
         "வணக்கம்",
-    ), '"வணக்கம்" should not fails'
+    ), '"வணக்கம்" should not fail'
 
 
 def test_bad_markup():


### PR DESCRIPTION
It was broken in previous commits...
Also, passing `-1` seems to be better because finding length for encoded characters is depreciated in python, in Linux and macOS.
/cc @PhilippImhof 