### PR TITLE
Update setup and build instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ pip install manimpango
 
 For **Linux Users**, there are no Wheels. You must have a C compiler as well as **Pango** and its dependencies along with the **Pango** development headers. See [BUILDING](#BUILDING) for more information.
 
+## WORKFLOW SETUP / CONTRIBUTING
+
+To make it easier for developers to contribute, we have a pre-commit workflow that will check for `black` formatting and `flake`
+
 ## BUILDING
 
 ### Linux/MacOS
@@ -66,10 +70,6 @@ pip install manimpango --no-binary :all:
 #### Using `git` clones / Contributing
 
 Please remember to do this inside your poetry shell, if you want to use your **Manimpango** with **Manim**.
-
-```sh
-poetry shell
-```
 
 If you are using a clone of this repository, you will need [Cython](https://cython.org) which can be easily installed using `pip`:
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,6 @@ pip install -r requirements-dev.txt .
 Next, run the setup script:
 
 ```sh
-python setup.py install
 python setup.py build_ext -i
 ```
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ apt install libpango1.0-dev pkg-config python3-dev
 
 Or similar in your system's package manager.
 
-##### Using `tar` archives
+#### Using `tar` archives
 
 If you don't want to contribute to this repository, you can use the tar archives published in PyPi, or just use `pip` to install using
 
@@ -63,7 +63,9 @@ pip install manimpango --no-binary :all:
 
 **Note**: `pip` by default uses wheels, so make sure to pass the `--no-binary` parameter.
 
-##### Using `git` clones / Contributing
+#### Using `git` clones / Contributing
+
+Please remember to do this inside your poetry shell, if you want to use your **Manimpango** with **Manim**.
 
 If you are using a clone of this repository, you will need [Cython](https://cython.org) which can be easily installed using `pip`:
 
@@ -74,12 +76,11 @@ pip install Cython
 After that you can use `pip` to install the clone with the following command:
 
 ```sh
+pip install -r requirements-dev.txt
 pip install .
 ```
 
 You will need to this way if you want to *contribute* to **ManimPango**.
-
-Please remember to do this inside your poetry shell, if you want to use your **Manimpango** with **Manim**.
 
 ### Contributing with Windows
 

--- a/README.md
+++ b/README.md
@@ -76,8 +76,7 @@ pip install Cython
 After that you can use `pip` to install the clone with the following command:
 
 ```sh
-pip install -r requirements-dev.txt
-pip install .
+pip install -r requirements-dev.txt .
 ```
 
 You will need to this way if you want to *contribute* to **ManimPango**.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,12 @@ For **Linux Users**, there are no Wheels. You must have a C compiler as well as 
 
 ## WORKFLOW SETUP / CONTRIBUTING
 
-To make it easier for developers to contribute, we have a pre-commit workflow that will check for `black` formatting and `flake`
+To make it easier for developers to contribute, we have a pre-commit workflow that will check for `black` formatting and `flake` checking.
+
+```sh
+pip install pre-commit
+pre-commit install
+```
 
 ## BUILDING
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,8 @@ Please remember to do this inside your virtual environment, if you want to use y
 
 ```sh
 python -m venv ./venv
-source venv/bin/activate
+source venv/bin/activate # Linux/macOS
+venv\Scripts\activate # Windows
 ```
 
 If you are using a clone of this repository, you will need [Cython](https://cython.org) which can be easily installed using `pip`:

--- a/README.md
+++ b/README.md
@@ -69,7 +69,13 @@ pip install manimpango --no-binary :all:
 
 #### Using `git` clones / Contributing
 
-Please remember to do this inside your poetry shell, if you want to use your **Manimpango** with **Manim**.
+Please remember to do this inside your virtual environment, if you want to use your **Manimpango** with **Manim**.
+
+```sh
+pip install virtualenv
+python -m venv ./venv
+source venv/bin/activate
+```
 
 If you are using a clone of this repository, you will need [Cython](https://cython.org) which can be easily installed using `pip`:
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,6 @@ pip install manimpango --no-binary :all:
 Please remember to do this inside your virtual environment, if you want to use your **Manimpango** with **Manim**.
 
 ```sh
-pip install virtualenv
 python -m venv ./venv
 source venv/bin/activate
 ```

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ pip install Cython
 After that you can use `pip` to install the clone with the following command:
 
 ```sh
+pip install -e .
 pip install -r requirements-dev.txt .
 ```
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,10 @@ pip install manimpango --no-binary :all:
 
 Please remember to do this inside your poetry shell, if you want to use your **Manimpango** with **Manim**.
 
+```sh
+poetry shell
+```
+
 If you are using a clone of this repository, you will need [Cython](https://cython.org) which can be easily installed using `pip`:
 
 ```sh
@@ -77,6 +81,19 @@ After that you can use `pip` to install the clone with the following command:
 
 ```sh
 pip install -r requirements-dev.txt .
+```
+
+Next, run the setup script:
+
+```sh
+python setup.py install
+python setup.py build_ext -i
+```
+
+After installation is complete, you should be able to run pytest:
+
+```sh
+pytest
 ```
 
 You will need to this way if you want to *contribute* to **ManimPango**.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,4 +5,4 @@ requires = ["setuptools", "wheel","Cython>=0.27"]
 name = "ManimPango"
 description = "Binding for Pango to use with Manim."
 version = "0.2.5.post0"
-authors = ["The Manim Community Developers"]
+authors = ["The Manim Community Developers", "Naveen M K <naveen@syrusdark.website>"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,2 @@
 [build-system]
 requires = ["setuptools", "wheel","Cython>=0.27"]
-
-[tool.poetry]
-name = "ManimPango"
-description = "Binding for Pango to use with Manim."
-version = "0.2.5.post0"
-authors = ["The Manim Community Developers", "Naveen M K <naveen@syrusdark.website>"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,8 @@
 [build-system]
 requires = ["setuptools", "wheel","Cython>=0.27"]
+
+[tool.poetry]
+name = "ManimPango"
+description = "Binding for Pango to use with Manim."
+version = "0.2.5.post0"
+authors = ["The Manim Community Developers"]


### PR DESCRIPTION
Help developers set up pre-commit workflow, virtual environment, and necessary dependencies in order to run `pytest` successfully.