### PR TITLE
Run fonts tests in a subprocess

### DIFF
--- a/tests/test_fonts.py
+++ b/tests/test_fonts.py
@@ -1,5 +1,9 @@
 # -*- coding: utf-8 -*-
+import os
+import subprocess
 import sys
+import textwrap
+from contextlib import contextmanager
 from pathlib import Path
 from shutil import copyfile
 
@@ -8,15 +12,33 @@ import pytest
 import manimpango
 
 from . import FONT_DIR
-from ._manim import MarkupText, Text
+from ._manim import MarkupText
 
-font_lists = {
-    (FONT_DIR / "AdobeVFPrototype.ttf").absolute(): "Adobe Variable Font Prototype",
-    (
-        FONT_DIR / "BungeeColor-Regular_colr_Windows.ttf"
-    ).absolute(): "Bungee Color Regular",
-    (FONT_DIR / "MaShanZheng-Regular.ttf").absolute(): "Ma Shan Zheng",
-}
+
+@contextmanager
+def register_font(font_file: Path):
+    font_file = os.fspath(font_file)
+    init = manimpango.list_fonts()
+    assert manimpango.register_font(font_file), "Invalid Font possibly."
+    final = manimpango.list_fonts()
+    yield list(set(final) - set(init))[0]
+    assert manimpango.unregister_font(font_file), "Can't unregister Font"
+
+
+def font_list():
+    _t = [
+        (FONT_DIR / "AdobeVFPrototype.ttf").absolute(),
+        (FONT_DIR / "BungeeColor-Regular_colr_Windows.ttf").absolute(),
+        (FONT_DIR / "MaShanZheng-Regular.ttf").absolute(),
+    ]
+    _d = {}
+    for i in _t:
+        with register_font(i) as f:
+            _d[i] = f
+    return _d
+
+
+font_lists_dict = font_list()
 
 
 def test_unicode_font_name(tmpdir):
@@ -26,46 +48,51 @@ def test_unicode_font_name(tmpdir):
     assert manimpango.unregister_font(final_font)
 
 
-@pytest.mark.parametrize("font_name", font_lists)
-def test_register_font(font_name):
-    intial = manimpango.list_fonts()
-    assert manimpango.register_font(str(font_name)), "Invalid Font possibly."
-    final = manimpango.list_fonts()
-    assert intial != final
-
-
-@pytest.mark.parametrize("font_name", font_lists.values())
-def test_warning(capfd, font_name):
-    print(font_name)
-    Text("Testing", font=font_name)
-    captured = capfd.readouterr()
-    assert "Pango-WARNING **" not in captured.err, "Looks like pango raised a warning?"
-
-
-@pytest.mark.skipif(
-    sys.platform.startswith("linux"), reason="unsupported api for linux"
-)
-@pytest.mark.parametrize("font_name", font_lists)
-def test_unregister_font(font_name):
-    intial = manimpango.list_fonts()
-    assert manimpango.unregister_font(str(font_name)), "Failed to unregister the font"
-    final = manimpango.list_fonts()
-    assert intial != final
-
-
-@pytest.mark.skipif(
-    sys.platform.startswith("linux"), reason="unsupported api for linux"
-)
-@pytest.mark.parametrize("font_name", font_lists)
+@pytest.mark.parametrize("font_name", font_lists_dict)
 def test_register_and_unregister_font(font_name):
+    intial = manimpango.list_fonts()
     assert manimpango.register_font(str(font_name)), "Invalid Font possibly."
-    assert manimpango.unregister_font(str(font_name)), "Failed to unregister the font"
+    final = manimpango.list_fonts()
+    assert intial != final
+    assert manimpango.unregister_font(os.fspath(font_name)), "Can't unregister font."
+    assert intial == manimpango.list_fonts()
+
+
+@pytest.mark.skipif(
+    sys.platform.startswith("linux"), reason="no warning are raised for linux"
+)
+@pytest.mark.parametrize("font_file,font_name", font_lists_dict.items())
+def test_warning(font_file, font_name):
+    # this tests need to be run in a separate subprocess because
+    # of fontmap cache in Pango.
+    command = textwrap.dedent(
+        f"""\
+            from tests import set_dll_search_path
+            set_dll_search_path() # this is needed on Windows to run
+            import manimpango
+            import os
+            from tests._manim import Text
+            font_file = r'{os.fspath(font_file)}'
+            font_name = r'{font_name}'
+            intial = manimpango.list_fonts()
+            manimpango.register_font(os.fspath(font_file))
+            final = manimpango.list_fonts()
+            assert intial != final
+            Text("Testing", font=font_name)
+            manimpango.unregister_font(os.fspath(font_file))
+        """
+    )
+    a = subprocess.run(
+        [sys.executable, "-c", command], check=True, stderr=subprocess.PIPE
+    )
+    captured = a.stderr.decode()
+    assert "Pango-WARNING **" not in captured, "Looks like pango raised a warning?"
 
 
 @pytest.mark.skipif(
     sys.platform.startswith("linux"), reason="unsupported api for linux"
 )
-@pytest.mark.parametrize("font_name", font_lists)
+@pytest.mark.parametrize("font_name", font_lists_dict)
 @pytest.mark.skipif(sys.platform.startswith("darwin"), reason="always returns true")
 def test_fail_just_unregister(font_name):
     assert not manimpango.unregister_font(
@@ -77,7 +104,7 @@ def test_fail_just_unregister(font_name):
     sys.platform.startswith("win32"), reason="unsupported api for win32"
 )
 @pytest.mark.skipif(sys.platform.startswith("darwin"), reason="unsupported api for mac")
-def test_unregister_linux():
+def test_unregister_not_fail_linux():
     assert manimpango.unregister_font("random")
 
 
@@ -89,6 +116,7 @@ def test_adding_dummy_font(tmpdir):
     with open(dummy, "wb") as f:
         f.write(b"dummy")
     assert not manimpango.register_font(str(dummy)), "Registered a dummy font?"
+    assert not manimpango.fc_register_font(str(dummy)), "Registered a dummy font?"
 
 
 def test_simple_fonts_render(tmpdir):
@@ -105,7 +133,7 @@ def test_both_fc_and_register_font_are_same():
     assert manimpango.fc_unregister_font == manimpango.unregister_font
 
 
-@pytest.mark.parametrize("font_file", font_lists)
+@pytest.mark.parametrize("font_file", font_lists_dict)
 def test_fc_font_register(setup_fontconfig, font_file):
     intial = manimpango.list_fonts()
     assert manimpango.fc_register_font(str(font_file)), "Invalid Font possibly."

--- a/tests/test_list_fonts.py
+++ b/tests/test_list_fonts.py
@@ -5,7 +5,7 @@ import pytest
 
 import manimpango
 
-from .test_fonts import font_lists
+from .test_fonts import font_lists_dict as font_lists
 
 
 def test_whether_list():


### PR DESCRIPTION
This is needed so that tests don't fail when the order of the
tests changes. This happens because Pango cache's the fontmap
separately for each process and there is no way to clean/ stop
it from caching.
Also, contains some cleanup related to it.

It should fix test in https://github.com/ManimCommunity/ManimPango/pull/65