### PR TITLE
wheel-build: pango disable xft backend by default

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,7 +85,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, windows-2019]
+        os: [macos-10.15, windows-2019]
         architecture: [x86, x64]
         python-version: ['3.7', '3.8', '3.9', '3.10']
         include:
@@ -95,11 +95,11 @@ jobs:
           - os: windows-2019
             architecture: x86
             platform_id: win32
-          - os: macos-latest
+          - os: macos-10.15
             architecture: x64
             platform_id: macosx_x86_64
         exclude:
-          - os: macos-latest
+          - os: macos-10.15
             architecture: x86
     steps:
       - uses: actions/checkout@v2

--- a/packing/build_pango_mac.sh
+++ b/packing/build_pango_mac.sh
@@ -49,7 +49,7 @@ export PATH="$PATH:$PREFIX/bin"
 
 echo "::group::Install Meson"
 echo "Installing Meson and Ninja"
-pip3 install -U meson ninja
+pip3 install -U meson==0.60.3 ninja
 echo "::endgroup::"
 
 echo "::group::Removing the things from brew"

--- a/packing/build_pango_mac.sh
+++ b/packing/build_pango_mac.sh
@@ -57,6 +57,10 @@ brew uninstall --ignore-dependencies brotli
 brew uninstall --ignore-dependencies pcre
 brew uninstall --ignore-dependencies libpng
 brew uninstall --ignore-dependencies freetype
+brew uninstall --ignore-dependencies libxdmcp
+brew uninstall --ignore-dependencies libxcb
+brew uninstall --ignore-dependencies xorgproto
+brew uninstall --ignore-dependencies libxau
 echo "::endgroup::"
 
 export CFLAGS=" -w" # warning are just noise. Ignore it.
@@ -135,6 +139,7 @@ meson setup \
   --prefix=$PREFIX \
   --buildtype=release \
   -Dintrospection=disabled \
+  -Dxft=disabled \
   --default-library=shared \
   pango_builddir pango
 meson compile -C pango_builddir

--- a/packing/build_pango_mac.sh
+++ b/packing/build_pango_mac.sh
@@ -108,6 +108,7 @@ meson setup \
   -Dfontconfig=enabled \
   -Dfreetype=enabled \
   -Dtests=disabled \
+  -Dxlib=disabled \
   --force-fallback-for=expat,libpng,pixman \
   --default-library=shared \
   cairo_builddir cairo


### PR DESCRIPTION
It's useless for us. 
Fixes https://github.com/ManimCommunity/ManimPango/issues/73