### PR TITLE
Fix wheel build on macOS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-      - macos-wheels-fix
+      - fix-wheel-build
   release:
     types: [created]
 

--- a/packing/build_pango_mac.sh
+++ b/packing/build_pango_mac.sh
@@ -126,7 +126,7 @@ meson setup \
   -Dcoretext=enabled \
   -Dfreetype=enabled \
   -Dintrospection=disabled \
-  -Dglib=disabled \
+  -Dglib=enabled \
   --default-library=shared \
   harfbuzz_builddir harfbuzz
 meson compile -C harfbuzz_builddir


### PR DESCRIPTION
Currently, it fails on main with this error
```
  ../pango/pango/pango-layout.c:88:10: fatal error: 'hb-glib.h' file not found
  #include <hb-glib.h>
           ^~~~~~~~~~~
  1 error generated.
```
which should be fixed by this PR.