### PR TITLE
CI: fix wheels build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,63 +16,53 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-11, windows-2019]
-        bitness: [32, 64]
         include:
           # Run 32 and 64 bit version in parallel for Windows
-          - os: windows-2019
-            bitness: 64
+          - os: windows-2022
             platform_id: win_amd64
-          - os: windows-2019
-            bitness: 32
+            architecture: x64
+          - os: windows-2022
             platform_id: win32
-          - os: macos-11
-            bitness: 64
+            architecture: x86
+          - os: macos-13
             platform_id: macosx_x86_64
-        exclude:
-          - os: macos-11
-            bitness: 32
+            architecture: x64
+          - os: macos-14
+            platform_id: macosx_arm64
+            architecture: arm64
     env:
-      CIBW_BUILD: cp38-${{ matrix.platform_id }} cp39-${{ matrix.platform_id }} cp310-${{ matrix.platform_id }} cp311-${{ matrix.platform_id }} cp312-${{ matrix.platform_id }}
-      CIBW_SKIP: pp* cp35* cp36* cp37*
-      CIBW_BEFORE_BUILD_MACOS: "source packing/build_pango_mac.sh"
+      CIBW_BUILD: cp39-${{ matrix.platform_id }} cp310-${{ matrix.platform_id }} cp311-${{ matrix.platform_id }} cp312-${{ matrix.platform_id }} cp313-${{ matrix.platform_id }}
+      CIBW_SKIP: pp* cp36* cp37* cp38*
+      CIBW_BEFORE_BUILD_MACOS: "python packing/download_pango_macos.py ${{ matrix.architecture }}"
       CIBW_BEFORE_BUILD_WINDOWS: "python packing/download_dlls.py"
       CIBW_ENVIRONMENT_WINDOWS: "PKG_CONFIG_PATH='C:\\cibw\\vendor\\lib\\pkgconfig'"
       CIBW_ENVIRONMENT_MACOS: "PKG_CONFIG_PATH='/Users/runner/pangobuild/lib/pkgconfig'"
-      CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: python packing/inject-dlls.py {wheel} {dest_dir} C:\cibw\vendor\bin
       CIBW_TEST_REQUIRES: pytest pytest-cov
       CIBW_TEST_COMMAND: "bash {project}/packing/test_wheels.sh {project}"
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
-        name: Install Python
-        with:
-          python-version: "3.8"
-
-      - name: Install cibuildwheel
-        env:
-          event_name: ${{ github.event_name }}
-        continue-on-error: true
-        shell: bash
+      - uses: actions/checkout@v4
+      - name: Set Path for pkg-config
+        if: runner.os == 'windows'
         run: |
-          python -m pip install cibuildwheel==2.16.1
-          echo "$event_name"
+          $env:Path = "C:\cibw\pkg-config\bin;C:\cibw\vendor\bin;$($env:PATH)"
+          echo "$env:Path" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
       - name: Build wheels (Windows)
         if: runner.os == 'windows'
+        shell: pwsh
         run: |
-          $ErrorActionPreference = 'Stop'
-          $env:PATH="$env:PATH;C:\cibw\pkg-config\bin"
-          $env:PKG_CONFIG_PATH="C:\cibw\vendor\lib\pkgconfig"
           Copy-Item packing/LICENSE.bin .
           Rename-Item LICENSE.bin LICENSE.win32
-          python -m cibuildwheel --output-dir wheelhouse
 
       - name: Build wheels (Non-Windows)
         if: runner.os != 'windows'
         run: |
           cp packing/LICENSE.bin .
-          python -m cibuildwheel --output-dir wheelhouse
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.20.0
+        env:
+          PKG_CONFIG_PATH: "C:\\cibw\\vendor\\lib\\pkgconfig"
 
       - uses: actions/upload-artifact@v3
         with:
@@ -86,26 +76,32 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-11, windows-2019]
-        architecture: [x86, x64]
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        os: [windows-2022, macos-13, macos-14]
         include:
-          - os: windows-2019
-            architecture: x64
+          - os: windows-2022
             platform_id: win_amd64
-          - os: windows-2019
-            architecture: x86
-            platform_id: win32
-          - os: macos-11
             architecture: x64
-            platform_id: macosx_x86_64
-        exclude:
-          - os: macos-11
+          - os: windows-2022
+            platform_id: win32
             architecture: x86
-    steps:
-      - uses: actions/checkout@v3
+          - os: macos-13
+            platform_id: macosx_x86_64
+            architecture: x86_64
+          - os: macos-14
+            platform_id: macosx_arm64
+            architecture: arm64
 
-      - uses: actions/setup-python@v4
+        # include: [
+        #   {os: windows-2022, platform_id: win_amd64, architecture: x64},
+        #   {os: windows-2022, platform_id: win32, architecture: x86},
+        #   {os: macos-13, platform_id: macosx_x86_64, architecture: x86_64},
+        #   {os: macos-14, platform_id: macosx_arm64, architecture: arm64}
+        # ]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
         name: Install Python
         with:
           python-version: ${{ matrix.python-version }}
@@ -162,7 +158,7 @@ jobs:
     if: github.event_name== 'release'
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Python
         uses: actions/setup-python@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,35 +69,19 @@ jobs:
           path: ./wheelhouse/*.whl
           name: wheels-${{ runner.os }}-${{ matrix.platform_id }}
 
-  test_wheels:
-    name: Test wheels on ${{ matrix.os }}-${{ matrix.platform_id }}-${{ matrix.python-version }}
+  test_wheels_win:
+    name: Test wheels on Windows - ${{ matrix.platform_id }} (${{ matrix.python-version }})
     needs: [build_wheels]
-    runs-on: ${{ matrix.os }}
+    runs-on: windows-latest
     strategy:
       fail-fast: false
       matrix:
+        architecture: [x64, x86]
         python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
-        os: [windows-2022, macos-13, macos-14]
-        include:
-          - os: windows-2022
-            platform_id: win_amd64
-            architecture: x64
-          - os: windows-2022
-            platform_id: win32
-            architecture: x86
-          - os: macos-13
-            platform_id: macosx_x86_64
-            architecture: x86_64
-          - os: macos-14
-            platform_id: macosx_arm64
-            architecture: arm64
-
-        # include: [
-        #   {os: windows-2022, platform_id: win_amd64, architecture: x64},
-        #   {os: windows-2022, platform_id: win32, architecture: x86},
-        #   {os: macos-13, platform_id: macosx_x86_64, architecture: x86_64},
-        #   {os: macos-14, platform_id: macosx_arm64, architecture: arm64}
-        # ]
+        include: [
+          {platform_id: win_amd64, architecture: x64},
+          {platform_id: win32, architecture: x86},
+        ]
     steps:
       - uses: actions/checkout@v4
 
@@ -106,6 +90,48 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           architecture: ${{ matrix.architecture }}
+          allow-prereleases: true
+
+      - uses: actions/download-artifact@v3
+        with:
+          name: wheels-${{ runner.os }}-${{ matrix.platform_id }}
+          path: ~/wheelhouse
+
+      - name: Install test dependencies
+        run: |
+          pip install pytest pytest-cov
+
+      - name: Install wheels
+        run: |
+          pip install --no-index --find-links ~/wheelhouse ManimPango
+
+      - name: Run tests
+        shell: bash
+        run: |
+          bash packing/test_wheels.sh $(pwd)
+
+  test_wheels_mac:
+    name: Test wheels on macOS - ${{ matrix.platform_id }} (${{ matrix.python-version }})
+    needs: [build_wheels]
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        architecture: [x64, arm64]
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        include: [
+          {platform_id: macosx_x86_64, architecture: x64, os: macos-13},
+          {platform_id: macosx_arm64, architecture: arm64, os: macos-14},
+        ]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        name: Install Python
+        with:
+          python-version: ${{ matrix.python-version }}
+          architecture: ${{ matrix.architecture == 'arm64' && null || matrix.architecture }}
+          allow-prereleases: true
 
       - uses: actions/download-artifact@v3
         with:
@@ -126,7 +152,7 @@ jobs:
           bash packing/test_wheels.sh $(pwd)
 
   publish_wheels:
-    needs: [test_wheels]
+    needs: [test_wheels_mac, test_wheels_win]
     name: Upload wheels
     runs-on: ubuntu-latest
     if: github.event_name== 'release'
@@ -217,7 +243,7 @@ jobs:
           asset_content_type: application/gzip
 
   success:
-    needs: [test_wheels]
+    needs: [test_wheels_win, test_wheels_mac]
     runs-on: ubuntu-latest
     name: Building and testing of wheels success
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -147,3 +147,4 @@ cython_debug/
 
 #temp folder
 .pytest_temp
+.venv*

--- a/packing/download_pango_macos.py
+++ b/packing/download_pango_macos.py
@@ -4,7 +4,7 @@ import logging
 import os
 import re
 import shutil
-import struct
+import sys
 import tempfile
 import zipfile
 from pathlib import Path
@@ -12,33 +12,25 @@ from urllib.request import urlretrieve as download
 
 PANGO_VERSION = "1.54.0-v3"
 
-
-def get_platform():
-    if (struct.calcsize("P") * 8) == 32:
-        return "x86"
-    else:
-        return "x64"
-
-
 logging.basicConfig(format="%(levelname)s - %(message)s", level=logging.DEBUG)
 
 
-plat = get_platform()
-logging.debug(f"Found Platform as {plat}")
+plat = sys.argv[1]
+logging.debug(f"Platform is {plat}")
 
 download_url = (
     "https://github.com/naveen521kk/pango-build/releases"
-    f"/download/v{PANGO_VERSION}/pango-v{PANGO_VERSION}-windows-{plat}.zip"
+    f"/download/v{PANGO_VERSION}/pango-v{PANGO_VERSION}-mac-{plat}.zip"
 )
-final_location = Path(r"C:\cibw\vendor")
+final_location = Path(r"~/pangobuild").expanduser()
 download_location = Path(tempfile.mkdtemp())
 if final_location.exists():
     logging.info("Final Location already exists clearing it...")
     shutil.rmtree(str(final_location))
 os.makedirs(final_location)
 download_file = download_location / "build.zip"
-logging.info("Downloading Pango and Cairo Binaries for Windows...")
-logging.info("Url:%s", download_url)
+logging.info("Downloading Pango and Cairo Binaries for macOS...")
+logging.info("Url: %s", download_url)
 download(url=download_url, filename=download_file)
 logging.info(f"Download complete. Saved to {download_file}.")
 logging.info(f"Extracting {download_file} to {download_location}...")
@@ -50,7 +42,7 @@ os.remove(download_file)
 logging.info("Completed Extracting.")
 logging.info("Moving Files accordingly.")
 
-plat_location = download_location / f"pango-{plat}"
+plat_location = download_location / f"mac-pango-{plat}"
 for src_file in plat_location.glob("*"):
     logging.debug(f"Moving {src_file} to {final_location}...")
     shutil.move(str(src_file), str(final_location))
@@ -73,32 +65,3 @@ for i in pc_files.glob("*.pc"):
         final = rex.sub(new_place, content)
     with open(i, "w") as f:
         f.write(final)
-
-logging.info("Getting pkg-config")
-download(
-    url="https://github.com/naveen521kk/pango-build"
-    f"/releases/download/v{PANGO_VERSION}/pkgconf-windows.zip",
-    filename=download_file,
-)
-with zipfile.ZipFile(
-    download_file, mode="r", compression=zipfile.ZIP_DEFLATED
-) as file:  # noqa: E501
-    file.extractall(download_location)
-
-os.makedirs(str(final_location / "bin"), exist_ok=True)
-shutil.move(
-    str(download_location / "pkgconf" / "bin" / "pkgconf.exe"),
-    str(final_location / "bin"),
-)
-# alias pkgconf to pkg-config
-shutil.copy(
-    final_location / "bin" / "pkgconf.exe", final_location / "bin" / "pkg-config.exe"
-)
-
-# On MSVC, meson would create static libraries as
-# libcairo.a but setuptools doens't know about it.
-libreg = re.compile(r"lib(?P<name>\S*)\.a")
-libdir = final_location / "lib"
-for lib in libdir.glob("lib*.a"):
-    name = libreg.match(lib.name).group("name") + ".lib"
-    shutil.move(lib, libdir / name)


### PR DESCRIPTION
- Remove python 3.8 wheels and add python 3.13 wheels
- download_dlls: remove types and update to 1.54.0-v2
- Use prebuilt libraries for macOS