### PR TITLE
Fix race condition: serialize Pango/Cairo calls for thread safety

### DIFF
--- a/manimpango/__init__.py
+++ b/manimpango/__init__.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import os
 import sys
+import threading
 
 from ._version import __version__  # noqa: F403,F401
 
@@ -10,6 +11,13 @@ if os.name == "nt":  # pragma: no cover
         f"{os.pathsep}"
         f"{os.environ['PATH']}"
     )
+
+# Module-level lock for thread safety. Pango/Cairo use global state (the default
+# PangoCairoFontMap, Fontconfig config, etc.) that is not thread-safe. Additionally,
+# the `registered_fonts` set is shared mutable state read during rendering and written
+# during font registration. This lock serializes all access to these shared resources.
+_pango_lock = threading.Lock()
+
 try:
     from .register_font import *  # isort:skip # noqa: F403,F401
     from .cmanimpango import *  # noqa: F403,F401
@@ -33,3 +41,50 @@ feel free to contact us or create an issue on GitHub:
 Original error: {ie}
 """
     raise ImportError(msg)
+else:
+    # Wrap public API functions with the lock for thread safety.
+    # The star imports above bring in the unlocked implementations;
+    # the definitions below shadow them with locked versions.
+
+    from .cmanimpango import text2svg as _text2svg_impl
+    from .cmanimpango import MarkupUtils as _MarkupUtils
+    from .register_font import (
+        register_font as _register_font_impl,
+        unregister_font as _unregister_font_impl,
+        fc_register_font as _fc_register_font_impl,
+        fc_unregister_font as _fc_unregister_font_impl,
+        list_fonts as _list_fonts_impl,
+    )
+
+    def text2svg(*args, **kwargs):
+        with _pango_lock:
+            return _text2svg_impl(*args, **kwargs)
+
+    def register_font(font_path):
+        with _pango_lock:
+            return _register_font_impl(font_path)
+
+    def unregister_font(font_path):
+        with _pango_lock:
+            return _unregister_font_impl(font_path)
+
+    def fc_register_font(font_path):
+        with _pango_lock:
+            return _fc_register_font_impl(font_path)
+
+    def fc_unregister_font(font_path):
+        with _pango_lock:
+            return _fc_unregister_font_impl(font_path)
+
+    def list_fonts():
+        with _pango_lock:
+            return _list_fonts_impl()
+
+    # Wrap MarkupUtils.text2svg (a @staticmethod on a plain Python class)
+    _markup_text2svg_impl = _MarkupUtils.text2svg
+
+    def _locked_markup_text2svg(*args, **kwargs):
+        with _pango_lock:
+            return _markup_text2svg_impl(*args, **kwargs)
+
+    _MarkupUtils.text2svg = staticmethod(_locked_markup_text2svg)

--- a/manimpango/__init__.py
+++ b/manimpango/__init__.py
@@ -2,8 +2,9 @@
 import os
 import sys
 import threading
+from functools import wraps
 
-from ._version import __version__  # noqa: F403,F401
+from ._version import __version__  # noqa: F401
 
 if os.name == "nt":  # pragma: no cover
     os.environ["PATH"] = (
@@ -12,16 +13,46 @@ if os.name == "nt":  # pragma: no cover
         f"{os.environ['PATH']}"
     )
 
-# Module-level lock for thread safety. Pango/Cairo use global state (the default
-# PangoCairoFontMap, Fontconfig config, etc.) that is not thread-safe. Additionally,
-# the `registered_fonts` set is shared mutable state read during rendering and written
-# during font registration. This lock serializes all access to these shared resources.
+# Module-level lock for thread safety. Pango/Cairo access global state (the default
+# PangoCairoFontMap, Fontconfig config, etc.) and the `registered_fonts` set is shared
+# mutable state read during rendering and written during font registration. This lock
+# serializes all access to these shared resources.
 _pango_lock = threading.Lock()
 
+
+def _synchronized(func):
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        with _pango_lock:
+            return func(*args, **kwargs)
+    return wrapper
+
+
 try:
-    from .register_font import *  # isort:skip # noqa: F403,F401
-    from .cmanimpango import *  # noqa: F403,F401
-    from .enums import *  # noqa: F403,F401
+    from .register_font import (  # noqa: F401
+        registered_fonts,
+        RegisteredFont,
+    )
+    from .cmanimpango import (  # noqa: F401
+        TextSetting,
+        MarkupUtils,
+        pango_version,
+        cairo_version,
+    )
+    from .cmanimpango import text2svg as _text2svg_impl
+    from .register_font import (
+        register_font as _register_font_impl,
+        unregister_font as _unregister_font_impl,
+        fc_register_font as _fc_register_font_impl,
+        fc_unregister_font as _fc_unregister_font_impl,
+        list_fonts as _list_fonts_impl,
+    )
+    from .enums import (  # noqa: F401
+        Style,
+        Weight,
+        Variant,
+        Alignment,
+    )
 except ImportError as ie:  # pragma: no cover
     py_ver = ".".join(map(str, sys.version_info[:3]))
     msg = f"""
@@ -41,50 +72,11 @@ feel free to contact us or create an issue on GitHub:
 Original error: {ie}
 """
     raise ImportError(msg)
-else:
-    # Wrap public API functions with the lock for thread safety.
-    # The star imports above bring in the unlocked implementations;
-    # the definitions below shadow them with locked versions.
 
-    from .cmanimpango import text2svg as _text2svg_impl
-    from .cmanimpango import MarkupUtils as _MarkupUtils
-    from .register_font import (
-        register_font as _register_font_impl,
-        unregister_font as _unregister_font_impl,
-        fc_register_font as _fc_register_font_impl,
-        fc_unregister_font as _fc_unregister_font_impl,
-        list_fonts as _list_fonts_impl,
-    )
-
-    def text2svg(*args, **kwargs):
-        with _pango_lock:
-            return _text2svg_impl(*args, **kwargs)
-
-    def register_font(font_path):
-        with _pango_lock:
-            return _register_font_impl(font_path)
-
-    def unregister_font(font_path):
-        with _pango_lock:
-            return _unregister_font_impl(font_path)
-
-    def fc_register_font(font_path):
-        with _pango_lock:
-            return _fc_register_font_impl(font_path)
-
-    def fc_unregister_font(font_path):
-        with _pango_lock:
-            return _fc_unregister_font_impl(font_path)
-
-    def list_fonts():
-        with _pango_lock:
-            return _list_fonts_impl()
-
-    # Wrap MarkupUtils.text2svg (a @staticmethod on a plain Python class)
-    _markup_text2svg_impl = _MarkupUtils.text2svg
-
-    def _locked_markup_text2svg(*args, **kwargs):
-        with _pango_lock:
-            return _markup_text2svg_impl(*args, **kwargs)
-
-    _MarkupUtils.text2svg = staticmethod(_locked_markup_text2svg)
+text2svg = _synchronized(_text2svg_impl)
+register_font = _synchronized(_register_font_impl)
+unregister_font = _synchronized(_unregister_font_impl)
+fc_register_font = _synchronized(_fc_register_font_impl)
+fc_unregister_font = _synchronized(_fc_unregister_font_impl)
+list_fonts = _synchronized(_list_fonts_impl)
+MarkupUtils.text2svg = staticmethod(_synchronized(MarkupUtils.text2svg))


### PR DESCRIPTION
## Summary

- Adds a module-level `threading.Lock` to serialize all calls into Pango/Cairo
  and font registration, fixing a race condition caused by concurrent access to
  global state (the default `PangoCairoFontMap`, Fontconfig config, and the
  shared `registered_fonts` set).
- Replaces star imports (`from .cmanimpango import *`, etc.) with explicit
  imports and a `_synchronized` decorator, making the public API surface clear
  and the thread-safety wrapping declarative.

## Problem

Pango and Cairo use process-global state internally (the default font map,
Fontconfig configuration). When multiple threads call `text2svg`,
`MarkupUtils.text2svg`, or font registration functions concurrently, this
leads to corrupted state, segfaults, or incorrect rendering — particularly
in tools like Manim that render scenes in parallel.

## Approach

A single `threading.Lock` (`_pango_lock`) in `__init__.py` wraps every
public function that touches Pango/Cairo or the font registry. A small
`_synchronized` decorator (using `functools.wraps`) keeps the code DRY
and preserves function metadata (`__name__`, `__doc__`, etc.).

Only `manimpango/__init__.py` is changed — no modifications to the Cython
layer or `register_font.py`.