### PR TITLE
Fix Read the Docs build with modern setuptools

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,16 +16,16 @@
 # sys.path.insert(0, os.path.abspath(".."))
 
 
+from importlib.metadata import version as distribution_version
 from pathlib import Path
 
 # -- Project information -----------------------------------------------------
-from pkg_resources import get_distribution
 
 project = "ManimPango"
 copyright = "2021, The Manim Community Dev Team"
 author = "The Manim Community Dev Team"
 
-release = get_distribution("ManimPango").version
+release = distribution_version("ManimPango")
 version = ".".join(release.split(".")[:2])
 
 


### PR DESCRIPTION
## Summary

- replace the removed `pkg_resources` API in the Sphinx configuration
- read the installed ManimPango version through `importlib.metadata`

Read the Docs currently upgrades setuptools to 83, where `pkg_resources` is no longer available. This caused the configuration phase of [build 33903390](https://app.readthedocs.org/api/v2/build/33903390.txt) to fail.

## Testing

- built the package in a fresh Python 3.11 environment with setuptools 83.0.0
- successfully built the HTML documentation with Sphinx 9.0.4